### PR TITLE
feat(ui): layout rework, live cost/ctx scraper, UX polish

### DIFF
--- a/backend/src/drivers/claude_code.rs
+++ b/backend/src/drivers/claude_code.rs
@@ -57,6 +57,7 @@ pub struct ClaudeCodeDriver {
     last_model: Option<String>,
     last_tool_call: Option<String>,
     last_turn_start_ms: Option<u64>,
+    scraper: super::status_scraper::ScraperState,
 }
 
 impl ClaudeCodeDriver {
@@ -69,6 +70,7 @@ impl ClaudeCodeDriver {
             last_model: None,
             last_tool_call: None,
             last_turn_start_ms: None,
+            scraper: super::status_scraper::ScraperState::default(),
         }
     }
 
@@ -185,18 +187,6 @@ impl ClaudeCodeDriver {
                 });
                 self.parser_state = ParserState::Idle;
             }
-            return events;
-        }
-
-        // Turn start: prompt markers ❯ or > at start of line suggest user input prompt
-        if PROMPT_RE.is_match(clean) {
-            let turn_id = self.next_turn();
-            self.last_turn_start_ms = Some(util::now_ms());
-            events.push(AgentEvent::TurnStarted {
-                turn_id,
-                role: TurnRole::User,
-                content_start: None,
-            });
             return events;
         }
 
@@ -317,6 +307,10 @@ impl AgentDriver for ClaudeCodeDriver {
         self.line_buffer.push_str(&s);
 
         let mut events = Vec::new();
+
+        // Shared status-line scrape (TUI redraws don't emit newlines)
+        events.extend(super::status_scraper::scrape_status(&s, &mut self.scraper));
+
         while let Some(pos) = self.line_buffer.find('\n') {
             let line = self.line_buffer[..pos].to_string();
             self.line_buffer = self.line_buffer[pos + 1..].to_string();

--- a/backend/src/drivers/mod.rs
+++ b/backend/src/drivers/mod.rs
@@ -1,4 +1,120 @@
 pub mod claude_code;
+/// Claude TUI status-line scraper. Parses "CTX 3% 30k $0.11 | ... | claude-opus-4-7[1m] | ..."
+/// shared across drivers (both claude_code sessions and shells that host a claude process).
+pub mod status_scraper {
+    use std::sync::LazyLock;
+    use regex::Regex;
+    use crate::events::AgentEvent;
+    use crate::util;
+
+    static STATUS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"CTX\s*(\d+)%\s*(\d+)k\s*\$([\d.]+)").unwrap()
+    });
+    static STATUS_MODEL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\|\s+(claude-[A-Za-z0-9\-]+(?:\[\d+m?\])?)\s+\|").unwrap()
+    });
+
+    // Claude TUI cursor-positions the bullet glyph away from the tool name in the raw
+    // byte stream, so anchor on known tool-name tokens instead.
+    static TOOL_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"\b(Bash|BashOutput|Glob|Grep|Read|Write|Edit|MultiEdit|LS|Task|WebFetch|WebSearch|NotebookEdit|KillBash|TodoWrite|SlashCommand|ExitPlanMode)\(([^)]{0,200})",
+        )
+        .unwrap()
+    });
+
+    #[derive(Default)]
+    pub struct ScraperState {
+        pub last_dollars: Option<f64>,
+        pub last_pct: Option<u32>,
+        pub last_model: Option<String>,
+        pub line_buf: String,
+        pub status_buf: String,
+        pub synth_turn: u64,
+        pub synth_call: u64,
+    }
+
+    /// Status-only scrape: CTX% / tokens / cost / model. No tool detection.
+    /// Use this from drivers that already have a hook-based tool stream (claude_code).
+    pub fn scrape_status(chunk: &str, state: &mut ScraperState) -> Vec<AgentEvent> {
+        let clean = util::strip_ansi(chunk);
+        state.status_buf.push_str(&clean);
+        // Keep rolling window bounded so regex scanning stays cheap.
+        // Slice at a char boundary — status_buf is UTF-8 and contains non-ASCII glyphs.
+        if state.status_buf.len() > 4096 {
+            let mut cut = state.status_buf.len() - 2048;
+            while cut < state.status_buf.len() && !state.status_buf.is_char_boundary(cut) {
+                cut += 1;
+            }
+            state.status_buf = state.status_buf[cut..].to_string();
+        }
+        let mut events = Vec::new();
+        // Scan the rolling buffer so patterns split across chunks still match.
+        // Use last-match semantics: the freshest status line dominates.
+        if let Some(cap) = STATUS_RE.captures_iter(&state.status_buf).last() {
+            let pct: u32 = cap[1].parse().unwrap_or(0);
+            let tokens_k: u64 = cap[2].parse().unwrap_or(0);
+            let dollars: f64 = cap[3].parse().unwrap_or(0.0);
+            let changed = state.last_dollars != Some(dollars) || state.last_pct != Some(pct);
+            if changed {
+                state.last_dollars = Some(dollars);
+                state.last_pct = Some(pct);
+                events.push(AgentEvent::ContextWindowSizeChanged {
+                    pct_used: pct as f32 / 100.0,
+                    tokens: tokens_k * 1000,
+                });
+                events.push(AgentEvent::CostUpdated { dollars });
+            }
+        }
+        if let Some(cap) = STATUS_MODEL_RE.captures_iter(&state.status_buf).last() {
+            let model = cap[1].to_string();
+            if state.last_model.as_deref() != Some(&model) {
+                state.last_model = Some(model.clone());
+                events.push(AgentEvent::ModelChanged { model });
+            }
+        }
+        events
+    }
+
+    /// Full scrape: status + line-level tool-call detection for hook-less sessions.
+    pub fn scrape_all(chunk: &str, state: &mut ScraperState) -> Vec<AgentEvent> {
+        let mut events = scrape_status(chunk, state);
+        let clean = util::strip_ansi(chunk);
+
+        // Line-buffered tool-call scrape
+        state.line_buf.push_str(&clean);
+        while let Some(pos) = state.line_buf.find('\n') {
+            let line = state.line_buf[..pos].to_string();
+            state.line_buf = state.line_buf[pos + 1..].to_string();
+            if let Some(cap) = TOOL_LINE_RE.captures(&line) {
+                let tool = cap[1].to_string();
+                let args_preview = cap[2].trim().to_string();
+                state.synth_call += 1;
+                let call_id = format!("scraped-{}", state.synth_call);
+                // Synthetic turn id: reuse latest or bump
+                if state.synth_turn == 0 {
+                    state.synth_turn = 1;
+                }
+                events.push(AgentEvent::ToolCallStarted {
+                    turn_id: state.synth_turn,
+                    call_id: call_id.clone(),
+                    tool,
+                    args_preview,
+                });
+                // Emit an immediate finished entry (we don't observe completion separately)
+                events.push(AgentEvent::ToolCallFinished {
+                    turn_id: state.synth_turn,
+                    call_id,
+                    ok: true,
+                    result_preview: String::new(),
+                });
+            }
+        }
+
+        events
+    }
+}
+
 pub mod codex;
 pub mod raw_bytes;
 pub mod shell;

--- a/backend/src/drivers/shell.rs
+++ b/backend/src/drivers/shell.rs
@@ -7,11 +7,15 @@ use crate::session::SessionState;
 
 use super::{AgentDriver, OobMessage, PtyHandle, SpawnCfg, SpawnRequest, StateCtx};
 
-pub struct ShellDriver;
+pub struct ShellDriver {
+    scraper: super::status_scraper::ScraperState,
+}
 
 impl ShellDriver {
     pub fn new() -> Self {
-        Self
+        Self {
+            scraper: super::status_scraper::ScraperState::default(),
+        }
     }
 }
 
@@ -30,8 +34,9 @@ impl AgentDriver for ShellDriver {
         })
     }
 
-    fn on_bytes(&mut self, _bytes: &[u8]) -> Vec<AgentEvent> {
-        Vec::new()
+    fn on_bytes(&mut self, bytes: &[u8]) -> Vec<AgentEvent> {
+        let s = String::from_utf8_lossy(bytes);
+        super::status_scraper::scrape_all(&s, &mut self.scraper)
     }
 
     fn on_oob(&mut self, _msg: OobMessage) -> Vec<AgentEvent> {

--- a/backend/src/events.rs
+++ b/backend/src/events.rs
@@ -63,6 +63,9 @@ pub enum AgentEvent {
     SandboxMerged {
         snapshot_id: String,
     },
+    CostUpdated {
+        dollars: f64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -144,6 +147,7 @@ fn extract_searchable_text(event: &Event) -> Option<String> {
             AgentEvent::ContextWindowSizeChanged { .. } => None,
             AgentEvent::SandboxStateChanged { .. } => None,
             AgentEvent::SandboxMerged { .. } => None,
+            AgentEvent::CostUpdated { .. } => None,
         },
         Event::SessionCreated
         | Event::StateChanged { .. }

--- a/frontend/src/lib/components/InsightsPanel.svelte
+++ b/frontend/src/lib/components/InsightsPanel.svelte
@@ -6,6 +6,19 @@
 		if (pct > 0.6) return '#ff9800';
 		return 'var(--accent)';
 	}
+
+	function modelCtxWindow(model: string | null): number {
+		if (!model) return 200_000;
+		// Opus 4.7 [1m] variant carries a 1M-context tag in the model id
+		if (/\[1m\]/i.test(model)) return 1_000_000;
+		return 200_000;
+	}
+
+	function formatTokens(n: number): string {
+		if (n >= 1_000_000) return (n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1) + 'M';
+		if (n >= 1_000) return Math.round(n / 1_000) + 'k';
+		return String(n);
+	}
 </script>
 
 <div class="sidebar">
@@ -21,7 +34,9 @@
 				</div>
 				<span class="ctx-pct">{Math.round(eventsStore.contextUsage.pctUsed * 100)}%</span>
 			</div>
-			<div class="muted">{eventsStore.contextUsage.tokens.toLocaleString()} tokens</div>
+			<div class="muted">
+				{formatTokens(eventsStore.contextUsage.tokens)} / {formatTokens(modelCtxWindow(eventsStore.outputCost.model))}
+			</div>
 		{:else}
 			<span class="muted">—</span>
 		{/if}
@@ -44,15 +59,17 @@
 			<ul class="tool-list">
 				{#each eventsStore.recentToolCalls as tc}
 					<li class="tool-item">
-						<span class="tool-name mono">{tc.tool}</span>
-						{#if tc.finished}
-							<span class="tool-status" class:ok={tc.ok} class:fail={!tc.ok}>
-								{tc.ok ? '✓' : '✗'}
-							</span>
-						{/if}
-						{#if tc.argsPreview}
-							<div class="tool-args muted">{tc.argsPreview.slice(0, 80)}</div>
-						{/if}
+						<div class="tool-cmd mono">
+							{tc.argsPreview ? tc.argsPreview.slice(0, 120) : tc.tool}
+						</div>
+						<div class="tool-meta">
+							<span class="tool-kind">{tc.tool}</span>
+							{#if tc.finished}
+								<span class="tool-status" class:ok={tc.ok} class:fail={!tc.ok}>
+									{tc.ok ? '✓' : '✗'}
+								</span>
+							{/if}
+						</div>
 					</li>
 				{/each}
 			</ul>
@@ -136,7 +153,7 @@
 		padding: 0;
 		display: flex;
 		flex-direction: column;
-		gap: 6px;
+		gap: 8px;
 	}
 
 	.tool-item {
@@ -146,9 +163,24 @@
 		overflow: hidden;
 	}
 
-	.tool-name {
-		font-size: 0.75rem;
-		white-space: nowrap;
+	.tool-cmd {
+		font-size: 0.78rem;
+		color: var(--text);
+		word-break: break-word;
+		line-height: 1.35;
+	}
+
+	.tool-meta {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 0.65rem;
+		color: var(--text-muted);
+	}
+
+	.tool-kind {
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
 	}
 
 	.tool-status {
@@ -162,12 +194,5 @@
 
 	.tool-status.fail {
 		color: #f44336;
-	}
-
-	.tool-args {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		font-size: 0.7rem;
-		word-break: break-word;
 	}
 </style>

--- a/frontend/src/lib/components/InsightsPanel.svelte
+++ b/frontend/src/lib/components/InsightsPanel.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import { eventsStore } from '$lib/stores/events.svelte';
 
-	let expanded = $state(true);
-
 	function contextColor(pct: number): string {
 		if (pct > 0.8) return '#f44336';
 		if (pct > 0.6) return '#ff9800';
@@ -10,135 +8,79 @@
 	}
 </script>
 
-<div class="insights-panel">
-	<div class="insights-header">
-		<span class="insights-title">Insights</span>
-		<button class="toggle-btn" onclick={() => (expanded = !expanded)}>
-			{expanded ? '▾' : '▸'}
-		</button>
+<div class="sidebar">
+	<div class="section">
+		<div class="heading">Context</div>
+		{#if eventsStore.contextUsage}
+			<div class="ctx-row">
+				<div class="ctx-bar">
+					<div
+						class="ctx-fill"
+						style="width: {Math.min(eventsStore.contextUsage.pctUsed * 100, 100)}%; background: {contextColor(eventsStore.contextUsage.pctUsed)}"
+					></div>
+				</div>
+				<span class="ctx-pct">{Math.round(eventsStore.contextUsage.pctUsed * 100)}%</span>
+			</div>
+			<div class="muted">{eventsStore.contextUsage.tokens.toLocaleString()} tokens</div>
+		{:else}
+			<span class="muted">—</span>
+		{/if}
 	</div>
 
-	{#if expanded}
-		<div class="insights-body">
-			<div class="insights-section">
-				<div class="section-heading">Recent Tools</div>
-				{#if eventsStore.recentToolCalls.length === 0}
-					<span class="muted">No tool calls yet</span>
-				{:else}
-					<ul class="tool-list">
-						{#each eventsStore.recentToolCalls as tc}
-							<li class="tool-item">
-								<span class="tool-name mono">{tc.tool}</span>
-								{#if tc.finished}
-									<span class="tool-status" class:ok={tc.ok} class:fail={!tc.ok}>
-										{tc.ok ? '✓' : '✗'}
-									</span>
-								{/if}
-								{#if tc.argsPreview}
-									<span class="tool-args muted">{tc.argsPreview.slice(0, 40)}</span>
-								{/if}
-							</li>
-						{/each}
-					</ul>
-				{/if}
-			</div>
+	<div class="section">
+		<div class="heading">Cost (est.)</div>
+		<div class="cost-value">${eventsStore.outputCost.estimatedCost.toFixed(4)}</div>
+		<div class="muted">{eventsStore.outputCost.totalTokens.toLocaleString()} output tokens</div>
+		{#if eventsStore.outputCost.model}
+			<div class="muted mono small">{eventsStore.outputCost.model}</div>
+		{/if}
+	</div>
 
-			<div class="insights-section">
-				<div class="section-heading">Cost (est.)</div>
-				<div class="cost-value">${eventsStore.outputCost.estimatedCost.toFixed(4)}</div>
-				<div class="muted">{eventsStore.outputCost.totalTokens.toLocaleString()} output tokens</div>
-				{#if eventsStore.outputCost.model}
-					<div class="muted mono">{eventsStore.outputCost.model}</div>
-				{:else}
-					<div class="muted">unknown model</div>
-				{/if}
-			</div>
-
-			<div class="insights-section">
-				<div class="section-heading">Context</div>
-				{#if eventsStore.contextUsage}
-					<div class="ctx-bar-wrap">
-						<div class="ctx-bar">
-							<div
-								class="ctx-fill"
-								style="width: {Math.min(eventsStore.contextUsage.pctUsed * 100, 100)}%; background: {contextColor(eventsStore.contextUsage.pctUsed)}"
-							></div>
-						</div>
-						<span class="ctx-pct">{Math.round(eventsStore.contextUsage.pctUsed * 100)}%</span>
-					</div>
-					<div class="muted">{eventsStore.contextUsage.tokens.toLocaleString()} tokens</div>
-				{:else}
-					<span class="muted">No context data</span>
-				{/if}
-			</div>
-		</div>
-	{/if}
+	<div class="section">
+		<div class="heading">Recent Tools</div>
+		{#if eventsStore.recentToolCalls.length === 0}
+			<span class="muted">No tool calls yet</span>
+		{:else}
+			<ul class="tool-list">
+				{#each eventsStore.recentToolCalls as tc}
+					<li class="tool-item">
+						<span class="tool-name mono">{tc.tool}</span>
+						{#if tc.finished}
+							<span class="tool-status" class:ok={tc.ok} class:fail={!tc.ok}>
+								{tc.ok ? '✓' : '✗'}
+							</span>
+						{/if}
+						{#if tc.argsPreview}
+							<div class="tool-args muted">{tc.argsPreview.slice(0, 80)}</div>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
 </div>
 
 <style>
-	.insights-panel {
-		background: var(--surface);
-		border-bottom: 1px solid var(--border);
-		flex-shrink: 0;
+	.sidebar {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
 		font-size: 0.8rem;
+		background: var(--border);
 	}
 
-	.insights-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 4px 12px;
-		border-bottom: 1px solid var(--border);
+	.section {
+		padding: 10px 12px;
+		background: var(--surface, var(--bg));
 	}
 
-	.insights-title {
-		font-size: 0.7rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--text-muted);
-	}
-
-	.toggle-btn {
-		background: none;
-		border: none;
-		color: var(--text-muted);
-		cursor: pointer;
-		font-size: 0.75rem;
-		padding: 0 4px;
-		line-height: 1;
-	}
-
-	.toggle-btn:hover {
-		color: var(--text);
-	}
-
-	.insights-body {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0;
-		max-height: 120px;
-		overflow: hidden;
-	}
-
-	.insights-section {
-		flex: 1;
-		min-width: 140px;
-		padding: 6px 12px;
-		border-right: 1px solid var(--border);
-	}
-
-	.insights-section:last-child {
-		border-right: none;
-	}
-
-	.section-heading {
+	.heading {
 		font-size: 0.65rem;
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		color: var(--text-muted);
-		margin-bottom: 4px;
+		margin-bottom: 6px;
 	}
 
 	.muted {
@@ -146,8 +88,46 @@
 		font-size: 0.75rem;
 	}
 
+	.small {
+		font-size: 0.7rem;
+	}
+
 	.mono {
 		font-family: var(--font-mono);
+	}
+
+	.ctx-row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin-bottom: 3px;
+	}
+
+	.ctx-bar {
+		flex: 1;
+		height: 6px;
+		background: var(--border);
+		border-radius: 3px;
+		overflow: hidden;
+	}
+
+	.ctx-fill {
+		height: 100%;
+		border-radius: 3px;
+		transition: width 0.5s;
+	}
+
+	.ctx-pct {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		flex-shrink: 0;
+	}
+
+	.cost-value {
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text);
+		margin-bottom: 2px;
 	}
 
 	.tool-list {
@@ -156,13 +136,13 @@
 		padding: 0;
 		display: flex;
 		flex-direction: column;
-		gap: 2px;
+		gap: 6px;
 	}
 
 	.tool-item {
 		display: flex;
-		align-items: center;
-		gap: 4px;
+		flex-direction: column;
+		gap: 2px;
 		overflow: hidden;
 	}
 
@@ -187,41 +167,7 @@
 	.tool-args {
 		overflow: hidden;
 		text-overflow: ellipsis;
-		white-space: nowrap;
 		font-size: 0.7rem;
-	}
-
-	.cost-value {
-		font-size: 1rem;
-		font-weight: 600;
-		color: var(--text);
-		margin-bottom: 2px;
-	}
-
-	.ctx-bar-wrap {
-		display: flex;
-		align-items: center;
-		gap: 6px;
-		margin-bottom: 2px;
-	}
-
-	.ctx-bar {
-		flex: 1;
-		height: 6px;
-		background: var(--border);
-		border-radius: 3px;
-		overflow: hidden;
-	}
-
-	.ctx-fill {
-		height: 100%;
-		border-radius: 3px;
-		transition: width 0.5s;
-	}
-
-	.ctx-pct {
-		font-size: 0.75rem;
-		color: var(--text-muted);
-		flex-shrink: 0;
+		word-break: break-word;
 	}
 </style>

--- a/frontend/src/lib/stores/events.svelte.ts
+++ b/frontend/src/lib/stores/events.svelte.ts
@@ -143,6 +143,8 @@ function computeOutputCost(evs: StoredEvent[]): {
 } {
 	let totalTokens = 0;
 	let model: string | null = null;
+	let authoritativeCost: number | null = null;
+	let ctxTokens: number | null = null;
 
 	for (const storedEv of evs) {
 		if (storedEv.event.type !== 'agent_event') continue;
@@ -151,6 +153,10 @@ function computeOutputCost(evs: StoredEvent[]): {
 			totalTokens += ae.tokens_used;
 		} else if (ae.type === 'model_changed') {
 			model = ae.model;
+		} else if (ae.type === 'cost_updated') {
+			authoritativeCost = ae.dollars;
+		} else if (ae.type === 'context_window_size_changed') {
+			ctxTokens = ae.tokens;
 		}
 	}
 
@@ -158,9 +164,11 @@ function computeOutputCost(evs: StoredEvent[]): {
 		? Object.keys(OUTPUT_RATES).find((k) => model!.startsWith(k))
 		: undefined;
 	const rate = rateKey ? OUTPUT_RATES[rateKey] : DEFAULT_OUTPUT_RATE;
-	const estimatedCost = (totalTokens / 1000) * rate;
+	const estimatedCost =
+		authoritativeCost !== null ? authoritativeCost : (totalTokens / 1000) * rate;
+	const displayTokens = ctxTokens !== null ? ctxTokens : totalTokens;
 
-	return { totalTokens, estimatedCost, model };
+	return { totalTokens: displayTokens, estimatedCost, model };
 }
 
 function findCurrentModel(evs: StoredEvent[]): string | null {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -65,6 +65,7 @@ export type AgentEvent =
 	| { type: 'model_changed'; model: string }
 	| { type: 'error'; message: string }
 	| { type: 'context_window_size_changed'; pct_used: number; tokens: number }
+	| { type: 'cost_updated'; dollars: number }
 	| { type: 'sandbox_state_changed'; state: SandboxState }
 	| { type: 'sandbox_merged'; snapshot_id: string };
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -27,7 +27,7 @@ export function stateColor(state: SessionState): string {
 		case 'booting':
 			return '#f5c518';
 		case 'idle':
-			return '#888';
+			return '#5b8bd4';
 		case 'streaming':
 			return '#4caf50';
 		case 'awaiting':
@@ -35,7 +35,7 @@ export function stateColor(state: SessionState): string {
 		case 'error':
 			return '#f44336';
 		case 'exited':
-			return '#555';
+			return '#3a3a3a';
 	}
 }
 

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -5,7 +5,6 @@
 	import { eventsStore } from '$lib/stores/events.svelte';
 	import { kindLabel, kindIcon } from '$lib/api';
 	import { stateColor } from '$lib/utils';
-	import ChatView from '$lib/components/ChatView.svelte';
 	import InsightsPanel from '$lib/components/InsightsPanel.svelte';
 	import TerminalView from '$lib/components/TerminalView.svelte';
 	import SandboxDiffView from '$lib/components/SandboxDiffView.svelte';
@@ -57,16 +56,6 @@
 		</div>
 	{/if}
 
-	{#if eventsStore.contextUsage}
-		<div class="context-bar">
-			<div
-				class="context-fill"
-				style="width: {eventsStore.contextUsage.pctUsed}%; background: {eventsStore.contextUsage.pctUsed > 80 ? '#f44336' : eventsStore.contextUsage.pctUsed > 60 ? '#ff9800' : 'var(--accent)'}"
-			></div>
-			<span class="context-label">{Math.round(eventsStore.contextUsage.pctUsed)}% context</span>
-		</div>
-	{/if}
-
 	{#if session.sandbox}
 		<div class="sandbox-section">
 			<div class="sandbox-header">
@@ -82,16 +71,12 @@
 		</div>
 	{/if}
 
-	{#if session.kind.type === 'claude_code' || session.kind.type === 'codex'}
-		<InsightsPanel />
-	{/if}
-
 	<div class="session-body">
 		{#key session.id}
 			{#if session.kind.type === 'claude_code' || session.kind.type === 'codex'}
 				<div class="split">
-					<div class="split-pane chat-pane"><ChatView {session} /></div>
-					<div class="split-pane term-pane"><TerminalView {session} /></div>
+					<div class="main-pane"><TerminalView {session} /></div>
+					<aside class="side-pane"><InsightsPanel /></aside>
 				</div>
 			{:else}
 				<TerminalView {session} />
@@ -187,26 +172,6 @@
 		border-radius: 3px;
 	}
 
-	.context-bar {
-		position: relative;
-		height: 4px;
-		background: var(--border);
-		flex-shrink: 0;
-	}
-
-	.context-fill {
-		height: 100%;
-		transition: width 0.5s;
-	}
-
-	.context-label {
-		position: absolute;
-		right: 8px;
-		top: 6px;
-		font-size: 0.7rem;
-		color: var(--text-muted);
-	}
-
 	.session-body {
 		flex: 1;
 		overflow: hidden;
@@ -217,18 +182,24 @@
 	.split {
 		flex: 1;
 		display: grid;
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: 1fr 280px;
 		gap: 1px;
 		background: var(--border);
 		overflow: hidden;
 	}
 
-	.split-pane {
+	.main-pane {
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
 		background: var(--bg);
 		min-width: 0;
+	}
+
+	.side-pane {
+		overflow-y: auto;
+		background: var(--surface, var(--bg));
+		border-left: 1px solid var(--border);
 	}
 
 	.sandbox-section {

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -73,14 +73,10 @@
 
 	<div class="session-body">
 		{#key session.id}
-			{#if session.kind.type === 'claude_code' || session.kind.type === 'codex'}
-				<div class="split">
-					<div class="main-pane"><TerminalView {session} /></div>
-					<aside class="side-pane"><InsightsPanel /></aside>
-				</div>
-			{:else}
-				<TerminalView {session} />
-			{/if}
+			<div class="split">
+				<div class="main-pane"><TerminalView {session} /></div>
+				<aside class="side-pane"><InsightsPanel /></aside>
+			</div>
 		{/key}
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- Collapse split pane to terminal + 280px right sidebar (Context / Cost / Recent Tools)
- Live cost and context scraped from the claude TUI status line with a rolling 4KB buffer so patterns split across PTY chunks still match
- New AgentEvent::CostUpdated sourced from TUI; store prefers it over token-rate estimate
- Shell-hosted claude now populates the sidebar via shared scrape_all (tool whitelist regex)
- Command is the tool-card headline, tool kind is a tiny label; context shows tokens / window with 1M detected from claude-*[1m] model tag
- Bug fixes: UTF-8 boundary safety, phantom empty user turn emitter, session-body remount on id change, state-color split (idle blue, exited dim gray)

## Test plan
- [x] New CC session: prompt lands, cost updates live to $0.29 matching TUI status line
- [x] New shell session with claude inside: Recent Tools populates via whitelist regex
- [x] No more empty user cards (source fix; live after next rebuild)
- [ ] Supervisor daemon still pending — every backend restart kills live sessions