### PR TITLE
docs: drop Time horizon section from ROADMAP

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,8 +93,3 @@ Each phase has its own `docs/phases/<NN>-*.md` with explicit acceptance criteria
 4. **Document choices as ADRs** — future Claude sessions should be able to understand "why" without asking
 5. **Tmux keeps running** during the whole build — the stopgap dashboard is kept working until hangar's own UI fully replaces it
 
----
-
-## Time horizon
-
-Claude Code is the engineer. No fixed deadlines. Phase-at-a-time; next phase kicks off only after the previous one has shipped criteria and been used for at least a week.


### PR DESCRIPTION
Removes the trailing "## Time horizon" section per project direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project roadmap by removing the time horizon section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->