### PR TITLE
feat: supervisor rollout — sessions survive backend restart

### DIFF
--- a/backend/src/bin/hangar-supervisor.rs
+++ b/backend/src/bin/hangar-supervisor.rs
@@ -10,8 +10,8 @@ use nix::unistd::Pid;
 use tracing::{info, warn};
 
 use hangard::supervisor_protocol::{
-    read_frame, send_fd, supervisor_sock_path, write_frame, SupervisorRequest, SupervisorResponse,
-    SupervisorSessionInfo,
+    hangar_state_dir, read_frame, send_fd, supervisor_sock_path, write_frame, SupervisorRequest,
+    SupervisorResponse, SupervisorSessionInfo,
 };
 
 struct ManagedSession {
@@ -34,12 +34,13 @@ async fn main() -> Result<()> {
         libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1usize, 0usize, 0usize, 0usize);
     }
 
-    let state_dir = dirs::state_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join("hangar");
+    let state_dir = hangar_state_dir();
     std::fs::create_dir_all(&state_dir)?;
 
     let sock_path = supervisor_sock_path();
+    if let Some(parent) = sock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let _ = std::fs::remove_file(&sock_path);
 
     let listener = tokio::net::UnixListener::bind(&sock_path)?;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -17,8 +17,7 @@ async fn main() -> Result<()> {
     let start_time = Instant::now();
     tracing_subscriber::fmt::init();
 
-    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-    let state_dir = home.join(".local/state/hangar");
+    let state_dir = hangard::supervisor_protocol::hangar_state_dir();
     std::fs::create_dir_all(&state_dir)?;
 
     let sessions_dir = state_dir.join("sessions");

--- a/backend/src/supervisor_protocol.rs
+++ b/backend/src/supervisor_protocol.rs
@@ -69,10 +69,36 @@ pub struct SupervisorSessionInfo {
     pub alive: bool,
 }
 
-pub fn supervisor_sock_path() -> PathBuf {
+/// Resolve the hangar state directory.
+///
+/// Precedence:
+/// 1. `HANGAR_STATE_DIR` env var (used as-is).
+/// 2. `dirs::state_dir()` (honors `XDG_STATE_HOME`, defaults to
+///    `~/.local/state` on Linux) joined with `hangar`.
+/// 3. Fallback: `/tmp/hangar` (only reached if neither home nor XDG resolve).
+///
+/// All persistent on-disk state — DB, ring buffers, supervisor socket —
+/// lives under this root, so an ephemeral test can redirect everything
+/// to a single temp dir.
+pub fn hangar_state_dir() -> PathBuf {
+    if let Ok(s) = std::env::var("HANGAR_STATE_DIR") {
+        return PathBuf::from(s);
+    }
     dirs::state_dir()
+        .or_else(|| dirs::home_dir().map(|h| h.join(".local/state")))
         .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("hangar/supervisor.sock")
+        .join("hangar")
+}
+
+/// Supervisor Unix socket path.
+///
+/// `HANGAR_SUPERVISOR_SOCK` takes precedence when set (absolute path);
+/// otherwise derives from [`hangar_state_dir`].
+pub fn supervisor_sock_path() -> PathBuf {
+    if let Ok(s) = std::env::var("HANGAR_SUPERVISOR_SOCK") {
+        return PathBuf::from(s);
+    }
+    hangar_state_dir().join("supervisor.sock")
 }
 
 pub fn write_frame(stream: &mut impl Write, data: &[u8]) -> Result<()> {

--- a/backend/tests/supervisor_restart.rs
+++ b/backend/tests/supervisor_restart.rs
@@ -1,0 +1,277 @@
+//! Integration test for supervisor survive-restart (#37).
+//!
+//! Spins up a real `hangar-supervisor` and `hangard` on an ephemeral
+//! socket / state dir / TCP port via the `HANGAR_SUPERVISOR_SOCK` +
+//! `HANGAR_STATE_DIR` + `HANGAR_PORT` env overrides, creates a shell
+//! session, writes bytes, kills hangard, starts a fresh hangard against
+//! the same supervisor, and asserts the session survived and the PTY
+//! still accepts I/O.
+//!
+//! Run: `cargo test --target-dir /tmp/hangar-ephemeral --test supervisor_restart -- --nocapture`
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+// ── env / harness ──────────────────────────────────────────────────────────
+
+struct Harness {
+    _tmp: TempDir,
+    state_dir: PathBuf,
+    sock_path: PathBuf,
+    config_dir: PathBuf,
+    port: u16,
+    base_url: String,
+    stamp_path: PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("mkdtemp");
+        let root = tmp.path().to_path_buf();
+        let state_dir = root.join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let sock_path = state_dir.join("supervisor.sock");
+        // Empty XDG_CONFIG_HOME so hangard falls back to default config (no sandbox, no push).
+        let config_dir = root.join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let port = pick_free_port();
+        let base_url = format!("http://127.0.0.1:{port}");
+        let stamp_path = root.join("stamp.txt");
+        Harness {
+            _tmp: tmp,
+            state_dir,
+            sock_path,
+            config_dir,
+            port,
+            base_url,
+            stamp_path,
+        }
+    }
+}
+
+fn pick_free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    l.local_addr().unwrap().port()
+}
+
+// ── child guards ───────────────────────────────────────────────────────────
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn start_supervisor(h: &Harness) -> ChildGuard {
+    let bin = env!("CARGO_BIN_EXE_hangar-supervisor");
+    let child = Command::new(bin)
+        .env("HANGAR_STATE_DIR", &h.state_dir)
+        .env("HANGAR_SUPERVISOR_SOCK", &h.sock_path)
+        .env("XDG_CONFIG_HOME", &h.config_dir)
+        .env("RUST_LOG", "warn")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn hangar-supervisor");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !h.sock_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "supervisor socket never appeared at {:?}",
+            h.sock_path
+        );
+        std::thread::sleep(Duration::from_millis(30));
+    }
+    ChildGuard(child)
+}
+
+fn start_hangard(h: &Harness) -> ChildGuard {
+    let bin = env!("CARGO_BIN_EXE_hangard");
+    let child = Command::new(bin)
+        .env("HANGAR_STATE_DIR", &h.state_dir)
+        .env("HANGAR_SUPERVISOR_SOCK", &h.sock_path)
+        .env("HANGAR_PORT", h.port.to_string())
+        .env("XDG_CONFIG_HOME", &h.config_dir)
+        .env("RUST_LOG", "warn")
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn hangard");
+    ChildGuard(child)
+}
+
+// ── HTTP helpers ───────────────────────────────────────────────────────────
+
+async fn wait_supervisor_connected(client: &reqwest::Client, base: &str) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(r) = client
+            .get(format!("{base}/api/v1/health"))
+            .timeout(Duration::from_millis(500))
+            .send()
+            .await
+        {
+            if let Ok(v) = r.json::<Value>().await {
+                if v.get("supervisor_connected") == Some(&Value::Bool(true)) {
+                    return;
+                }
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "hangard never reported supervisor_connected=true"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_hangard_down(client: &reqwest::Client, base: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let down = client
+            .get(format!("{base}/api/v1/health"))
+            .timeout(Duration::from_millis(200))
+            .send()
+            .await
+            .is_err();
+        if down {
+            return;
+        }
+        assert!(Instant::now() < deadline, "old hangard never went down");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn get_session_state(client: &reqwest::Client, base: &str, sid: &str) -> String {
+    let r = client
+        .get(format!("{base}/api/v1/sessions/{sid}"))
+        .send()
+        .await
+        .unwrap();
+    assert!(r.status().is_success(), "GET session: {}", r.status());
+    let v: Value = r.json().await.unwrap();
+    v["state"].as_str().unwrap().to_string()
+}
+
+fn wait_for_contents(path: &Path, needle: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(s) = std::fs::read_to_string(path) {
+            if s.contains(needle) {
+                return;
+            }
+        }
+        if Instant::now() > deadline {
+            let got = std::fs::read_to_string(path).unwrap_or_default();
+            panic!("{path:?} never contained {needle:?}; got: {got:?}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn sigterm(child: &ChildGuard) {
+    let pid = child.0.id() as i32;
+    let _ = nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid),
+        nix::sys::signal::Signal::SIGTERM,
+    );
+}
+
+// ── the test ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn shell_session_survives_hangard_restart() {
+    let h = Harness::new();
+    let _sup = start_supervisor(&h);
+    let mut hangard1 = start_hangard(&h);
+
+    let client = reqwest::Client::new();
+    wait_supervisor_connected(&client, &h.base_url).await;
+
+    // 1. Create a shell session.
+    let resp = client
+        .post(format!("{}/api/v1/sessions", h.base_url))
+        .json(&serde_json::json!({
+            "slug": "sup-it",
+            "kind": {"type": "shell"},
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "create session: {}",
+        resp.status()
+    );
+    let session: Value = resp.json().await.unwrap();
+    let sid = session["id"].as_str().unwrap().to_string();
+
+    // 2. Write a command that leaves a stamp on disk. /prompt is a raw
+    //    PTY write for the shell driver.
+    let stamp = h.stamp_path.display().to_string();
+    let pre_cmd = format!("echo SUP_BEFORE > {stamp}\n");
+    let r = client
+        .post(format!("{}/api/v1/sessions/{}/prompt", h.base_url, sid))
+        .json(&serde_json::json!({ "text": pre_cmd }))
+        .send()
+        .await
+        .unwrap();
+    assert!(r.status().is_success(), "pre-write: {}", r.status());
+    wait_for_contents(&h.stamp_path, "SUP_BEFORE", Duration::from_secs(10));
+
+    // 3. Record pre-restart state.
+    let state_before = get_session_state(&client, &h.base_url, &sid).await;
+    assert_ne!(
+        state_before, "exited",
+        "session should not be exited pre-restart"
+    );
+    let pid_before = hangard1.0.id();
+
+    // 4. SIGTERM hangard and wait for it to exit. Drop the guard so the
+    //    port is free for the replacement.
+    sigterm(&hangard1);
+    let _ = hangard1.0.wait();
+    drop(hangard1);
+    wait_hangard_down(&client, &h.base_url).await;
+
+    // 5. Start a fresh hangard pointed at the same supervisor, DB, ring.
+    let _hangard2 = start_hangard(&h);
+    wait_supervisor_connected(&client, &h.base_url).await;
+    // health reports uptime — just confirm the bin is a new process (not
+    //  strictly required, but nice to have an explicit check):
+    let pid_after = _hangard2.0.id();
+    assert_ne!(pid_before, pid_after, "hangard pid did not change");
+
+    // 6. Session must still be non-exited.
+    let state_after = get_session_state(&client, &h.base_url, &sid).await;
+    assert_ne!(
+        state_after, "exited",
+        "session flipped to exited across restart (before={state_before}, after={state_after})"
+    );
+
+    // 7. Write again — if the supervisor truly re-passed the same PTY fd
+    //    to the new hangard, the append lands on the same stamp file.
+    let post_cmd = format!("echo SUP_AFTER >> {stamp}\n");
+    let r = client
+        .post(format!("{}/api/v1/sessions/{}/prompt", h.base_url, sid))
+        .json(&serde_json::json!({ "text": post_cmd }))
+        .send()
+        .await
+        .unwrap();
+    assert!(r.status().is_success(), "post-write: {}", r.status());
+    wait_for_contents(&h.stamp_path, "SUP_AFTER", Duration::from_secs(10));
+
+    let contents = std::fs::read_to_string(&h.stamp_path).unwrap();
+    assert!(
+        contents.contains("SUP_BEFORE") && contents.contains("SUP_AFTER"),
+        "stamp file missing expected lines; got: {contents:?}"
+    );
+}

--- a/docs/decisions/0010-sessions-survive-restart.md
+++ b/docs/decisions/0010-sessions-survive-restart.md
@@ -1,7 +1,8 @@
 # ADR-0010: Sessions survive backend restart via supervisor pattern
 
-**Status:** Accepted
+**Status:** Accepted + Implemented
 **Date:** 2026-04-17
+**Implemented:** 2026-04-18 (branch `feat/supervisor-rollout`, parent issue #8)
 **Phase:** 2
 
 ## Context
@@ -36,3 +37,16 @@ Backend connects at startup, lists existing sessions, resumes event streams.
 ## Future work
 
 - Phase 2 spike: prototype supervisor first, validate fd handoff across backend restart before committing to full Phase 2 scope.
+
+## Implementation notes (2026-04-18)
+
+Landed behind #8 (rollout tickets #35 #36 #37 #38 #39).
+
+- Binary at `backend/src/bin/hangar-supervisor.rs`; protocol types in `backend/src/supervisor_protocol.rs`; client in `backend/src/supervisor_client.rs`.
+- Child-reaping path: `prctl(PR_SET_CHILD_SUBREAPER)` + an async `waitpid` loop. `KillMode=process` on the systemd unit so stopping the supervisor doesn't cascade-kill PTY children.
+- Runs as a **user** systemd unit (`systemd/hangar-supervisor.service`), not system-wide — socket lives at `$XDG_STATE_HOME/hangar/supervisor.sock` under the invoking user. Install runbook: [`docs/runbook/supervisor-install.md`](../runbook/supervisor-install.md).
+- Path/socket resolution is env-overridable via `HANGAR_STATE_DIR` + `HANGAR_SUPERVISOR_SOCK` (added for the integration test, also useful for second-instance dev).
+- On dev boxes, `hangar-supervisor.service` is enabled but `hangar.service` stays disabled because `hangard` is usually run manually from a tmux pane. Prod enables both.
+- Restart survival verified by `backend/tests/supervisor_restart.rs` (#37) and live on the optiplex box (#36 smoke run).
+
+Divergence from the ADR body: nothing material. The supervisor uses subreaper-only (no double-fork) because it's already the direct parent, and the parent-outlives-supervisor case is handled by systemd re-spawning the supervisor with `Restart=always`.

--- a/docs/phases/02-mvp-command-center.md
+++ b/docs/phases/02-mvp-command-center.md
@@ -1,6 +1,6 @@
 # Phase 2 — MVP Command Center
 
-**Status:** ✅ Complete
+**Status:** ✅ Complete (supervisor rollout #8 landed 2026-04-18 — see Implementation notes below)
 
 ## Goal
 
@@ -27,7 +27,7 @@ Rust workspace (`cargo` single crate, split into modules):
 - `hangard` — binary with `tokio` runtime, `axum` HTTP server, `tower-http` middleware
 - `session` module — `Session`, `SessionKind`, `SessionState`, state machine, SQLite persistence
 - `pty` module — wraps `portable-pty`, owns child process lifecycle, exposes byte streams
-- `supervisor` — holds PTY fds across backend restart via Unix socket handoff (or falls back to systemd re-parenting; spike)
+- `supervisor` — holds PTY fds across backend restart via Unix socket handoff. Landed as a separate `hangar-supervisor` binary (option (a) from Risks below). Rolled out on 2026-04-18 (issues #8, #35, #36, #37, #38, #39). Install runbook: [`docs/runbook/supervisor-install.md`](../runbook/supervisor-install.md). ADR: [`0010`](../decisions/0010-sessions-survive-restart.md) (Accepted + Implemented).
 - `ringbuf` module — 100 MB per-session output ring file with offset/length API
 - `events` module — `Event` enum, persistent log, broadcast bus (`tokio::sync::broadcast`)
 - `drivers/shell.rs`, `drivers/claude_code.rs`, `drivers/raw_bytes.rs`
@@ -146,3 +146,16 @@ Each milestone should be a PR with its own tests.
 - Branching
 - Sandboxing
 - Multi-node registration
+
+## Implementation notes
+
+### Supervisor rollout (2026-04-18, #8 / #35–#39)
+
+The supervisor bullet in Deliverables was a phase-2 spike at merge time but wasn't enabled on the box — `hangard` logged `supervisor not available, sessions won't survive restart` on every startup until this rollout. Now live:
+
+- `hangar-supervisor.service` is a user-level systemd unit (`~/.config/systemd/user/`). See [`docs/runbook/supervisor-install.md`](../runbook/supervisor-install.md) for install/upgrade/rollback.
+- On dev boxes only `hangar-supervisor.service` is enabled; `hangar.service` is documented but left disabled so the manual `target/release/hangard` running in tmux doesn't race the unit for port 3000. Prod enables both.
+- Path/socket resolution is env-overridable (`HANGAR_STATE_DIR`, `HANGAR_SUPERVISOR_SOCK`). Added for the restart integration test; doubles as a way to run a second instance on the same box.
+- Survive-restart is covered by `backend/tests/supervisor_restart.rs` (integration) and by the smoke script in the runbook (manual).
+
+No deliberate divergences from the ADR beyond dropping the double-fork fallback — `PR_SET_CHILD_SUBREAPER` was enough in practice.

--- a/docs/runbook/supervisor-install.md
+++ b/docs/runbook/supervisor-install.md
@@ -141,25 +141,34 @@ curl -s http://localhost:3000/api/v1/health | jq .supervisor_connected  # -> tru
 # 1. Create a shell session.
 SID=$(curl -sS -X POST http://localhost:3000/api/v1/sessions \
   -H 'content-type: application/json' \
-  -d '{"slug":"supervisor-smoke","kind":{"type":"shell"},"project_dir":"/home/george/Documents/hangar"}' \
-  | jq -r .session_id)
+  -d '{"slug":"sup-smoke","kind":{"type":"shell"}}' \
+  | jq -r .id)
 echo "session=$SID"
 
 # 2. Write something identifiable into the PTY.
+#    NB: the prompt endpoint's body field is `text`, not `prompt`.
 curl -sS -X POST "http://localhost:3000/api/v1/sessions/$SID/prompt" \
   -H 'content-type: application/json' \
-  -d '{"prompt":"echo HANGAR_SMOKE_$(date +%s) > /tmp/hangar-smoke.txt\n"}' >/dev/null
+  -d '{"text":"echo PRE_RESTART_$(date +%s) > /tmp/hangar-smoke.txt\n"}' >/dev/null
 
 # 3. Record pre-restart state.
 PID_BEFORE=$(pgrep -f 'target/release/hangard' | head -1)
 STATE_BEFORE=$(curl -s "http://localhost:3000/api/v1/sessions/$SID" | jq -r .state)
 echo "before: hangard_pid=$PID_BEFORE state=$STATE_BEFORE"
 
-# 4. Restart hangard. In dev (manual cargo run) send SIGTERM and restart it
-#    in its tmux pane; in prod use: systemctl --user restart hangar
+# 4. Restart hangard.
+#    Prod:  systemctl --user restart hangar
+#    Dev:   SIGTERM the manual hangard, then relaunch in its tmux pane:
 kill -TERM "$PID_BEFORE"
-# ...wait for the dev pane to relaunch hangard, or `systemctl --user restart hangar`
-sleep 5
+sleep 2
+tmux send-keys -t hangar-backend 'target/release/hangard' Enter
+# Poll until supervisor_connected is true again:
+for i in $(seq 1 20); do
+  sleep 1
+  CONN=$(curl -s --max-time 1 http://localhost:3000/api/v1/health \
+           | jq -r .supervisor_connected 2>/dev/null)
+  [ "$CONN" = "true" ] && break
+done
 
 # 5. Post-restart state.
 PID_AFTER=$(pgrep -f 'target/release/hangard' | head -1)
@@ -168,23 +177,50 @@ CONNECTED=$(curl -s http://localhost:3000/api/v1/health | jq -r .supervisor_conn
 echo "after:  hangard_pid=$PID_AFTER state=$STATE_AFTER supervisor_connected=$CONNECTED"
 
 # 6. Assertions.
-test "$PID_AFTER"    != "$PID_BEFORE"    && echo "OK: hangard pid changed"
-test "$STATE_AFTER"  =  "running"        && echo "OK: session still running"
-test "$CONNECTED"    =  "true"           && echo "OK: supervisor reconnected"
+test "$PID_AFTER"   != "$PID_BEFORE"           && echo "OK: hangard pid changed"
+test "$STATE_AFTER" != "exited"                && echo "OK: session not exited (state=$STATE_AFTER)"
+test "$CONNECTED"   =  "true"                  && echo "OK: supervisor reconnected"
 
 # 7. Prove the PTY still accepts writes.
 curl -sS -X POST "http://localhost:3000/api/v1/sessions/$SID/prompt" \
   -H 'content-type: application/json' \
-  -d '{"prompt":"cat /tmp/hangar-smoke.txt\n"}' >/dev/null
+  -d '{"text":"echo POST_RESTART_$(date +%s) >> /tmp/hangar-smoke.txt\n"}' >/dev/null
+sleep 1
+cat /tmp/hangar-smoke.txt   # expect BOTH a PRE_RESTART and POST_RESTART line
 ```
 
-Expected result: `hangard_pid` differs before/after, `state=running` both
-before and after, `supervisor_connected=true` after.
+Expected result: `hangard_pid` differs before/after; session `state` stays
+non-`exited` (canonical value is `idle` — `running` is an accepted alias);
+`supervisor_connected=true` after; `/tmp/hangar-smoke.txt` contains both a
+`PRE_RESTART_*` and `POST_RESTART_*` line, proving the same PTY fd was
+reattached by the new hangard.
 
 If `state` flips to `exited` after restart, do **not** fix in-place —
 file a detailed bug on #38 with: the two state payloads, `hangard` logs
 spanning the restart, and `journalctl --user -u hangar-supervisor` for
 the same window.
+
+### Recorded evidence (2026-04-18 optiplex)
+
+```
+BEFORE: hangard_pid=286405 state=idle
+(kill -TERM 286405; tmux send-keys 'target/release/hangard' Enter)
+AFTER:  hangard_pid=290669 state=idle supervisor_connected=true
+
+/tmp/hangar-smoke.txt:
+  PRE_RESTART_1776532174
+  POST_RESTART_1776532211
+
+hangard log (post-restart):
+  INFO hangard: connected to supervisor at ".../supervisor.sock"
+  INFO hangard: reattached session 01KPGS36GXXNHE7CSW...
+  INFO hangard: reattached session 01KPGQS843A5FAA09H...
+  INFO hangard: recovered 2 sessions from supervisor
+
+supervisor journal (spanning restart): spawn entry once, no
+"exited"/"reaped" for the smoke session — supervisor held the PTY fd
+across the hangard gap.
+```
 
 ---
 

--- a/docs/runbook/supervisor-install.md
+++ b/docs/runbook/supervisor-install.md
@@ -1,0 +1,199 @@
+# Supervisor install runbook
+
+How to install and run `hangar-supervisor` as a systemd user unit so PTY
+sessions survive a `hangard` restart.
+
+Related:
+- Parent: [#8 — Phase 2.3 Supervisor](https://github.com/georgenijo/hangar/issues/8)
+- ADR: [`docs/decisions/0010-sessions-survive-restart.md`](../decisions/0010-sessions-survive-restart.md)
+- Unit files: [`systemd/hangar-supervisor.service`](../../systemd/hangar-supervisor.service), [`systemd/hangar.service`](../../systemd/hangar.service)
+
+---
+
+## Architecture (one paragraph)
+
+`hangar-supervisor` is a small long-lived daemon that owns every PTY fd.
+`hangard` (the Rust backend) connects to it over a Unix socket and receives
+PTY fds via `SCM_RIGHTS`. When `hangard` restarts, the supervisor keeps
+running, child processes stay alive under it (via `PR_SET_CHILD_SUBREAPER`),
+and the new `hangard` re-attaches every fd on startup. If the supervisor
+itself dies, children are reparented to PID 1 and become unrecoverable —
+which is why the unit uses `Restart=always` and `KillMode=process` (a
+supervisor stop must NOT cascade-kill its children).
+
+Socket: `~/.local/state/hangar/supervisor.sock` (derived from
+`dirs::state_dir()` — resolves to `$XDG_STATE_HOME/hangar/` or
+`~/.local/state/hangar/`).
+
+---
+
+## Prerequisites
+
+- Linux with systemd user instance (`systemd --user`) available.
+- Repo checked out at `~/Documents/hangar` (if different, replace paths below).
+- Release binaries built: `backend/target/release/hangar-supervisor` and
+  `backend/target/release/hangard`.
+  ```bash
+  cd ~/Documents/hangar/backend
+  cargo build --release --bin hangar-supervisor --bin hangard
+  ```
+- A live graphical / lingering user session so the user systemd instance
+  is running. Headless boxes need `loginctl enable-linger $(whoami)` or
+  the units will stop when you log out.
+
+---
+
+## Install steps (dev box — supervisor only)
+
+This is the mode currently used on the optiplex dev box: `hangard` runs
+manually in a tmux pane via `cargo run --release --bin hangard`, so the
+`hangar.service` unit is installed but **not** enabled (enabling it would
+race the manual hangard for port 3000).
+
+```bash
+cd ~/Documents/hangar
+
+# 1. Install unit files into the user systemd search path.
+install -d ~/.config/systemd/user
+install -m 644 systemd/hangar-supervisor.service ~/.config/systemd/user/
+install -m 644 systemd/hangar.service           ~/.config/systemd/user/
+
+# 2. Pick up the new unit files.
+systemctl --user daemon-reload
+
+# 3. Enable + start the supervisor. Safe to re-run (idempotent).
+systemctl --user enable --now hangar-supervisor.service
+
+# 4. Verify.
+systemctl --user is-enabled hangar-supervisor   # -> enabled
+systemctl --user is-active  hangar-supervisor   # -> active
+ls -l ~/.local/state/hangar/supervisor.sock     # -> srw-rw---- ...
+```
+
+Then (re)start `hangard` in your dev tmux pane and confirm the handshake:
+
+```bash
+curl -s http://localhost:3000/api/v1/health | jq .
+# {"status":"ok","supervisor_connected":true,"uptime_s":...}
+```
+
+The backend logs should also show:
+
+```
+INFO  hangard: connected to supervisor at "/home/$USER/.local/state/hangar/supervisor.sock"
+```
+
+## Install steps (production — both units managed)
+
+Same as above but also enable `hangar.service`. `hangar.service` has
+`Requires=hangar-supervisor.service` + `After=hangar-supervisor.service`, so
+starting hangar will start the supervisor first.
+
+```bash
+systemctl --user enable --now hangar-supervisor.service
+systemctl --user enable --now hangar.service
+
+systemctl --user status hangar --no-pager | head
+curl -s http://localhost:3000/api/v1/health | jq .supervisor_connected
+# true
+```
+
+Do **not** do this on the optiplex dev box while a manual `cargo run`
+hangard is holding port 3000 — the unit will fail with `AddrInUse`.
+
+---
+
+## Uninstall / rollback
+
+```bash
+systemctl --user disable --now hangar hangar-supervisor 2>/dev/null || true
+rm -f ~/.config/systemd/user/hangar.service \
+      ~/.config/systemd/user/hangar-supervisor.service
+systemctl --user daemon-reload
+rm -f ~/.local/state/hangar/supervisor.sock
+```
+
+## Upgrading after a binary rebuild
+
+Because the unit uses `ExecStart=%h/Documents/hangar/backend/target/release/hangar-supervisor`,
+rebuilding the binary does **not** update the running supervisor — you
+must restart it. After `cargo build --release` finishes:
+
+```bash
+systemctl --user restart hangar-supervisor
+```
+
+Note: restarting the supervisor during active PTY work is safe only if the
+new supervisor starts fast enough to re-adopt subreaper'd children before
+they exit. For dev, prefer to drain sessions first.
+
+---
+
+## Verification (#36 survive-restart smoke test)
+
+Manual smoke test that a live session survives a `hangard` restart.
+Uses a `shell` session (no Claude auth required).
+
+```bash
+# 0. Sanity.
+curl -s http://localhost:3000/api/v1/health | jq .supervisor_connected  # -> true
+
+# 1. Create a shell session.
+SID=$(curl -sS -X POST http://localhost:3000/api/v1/sessions \
+  -H 'content-type: application/json' \
+  -d '{"slug":"supervisor-smoke","kind":{"type":"shell"},"project_dir":"/home/george/Documents/hangar"}' \
+  | jq -r .session_id)
+echo "session=$SID"
+
+# 2. Write something identifiable into the PTY.
+curl -sS -X POST "http://localhost:3000/api/v1/sessions/$SID/prompt" \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"echo HANGAR_SMOKE_$(date +%s) > /tmp/hangar-smoke.txt\n"}' >/dev/null
+
+# 3. Record pre-restart state.
+PID_BEFORE=$(pgrep -f 'target/release/hangard' | head -1)
+STATE_BEFORE=$(curl -s "http://localhost:3000/api/v1/sessions/$SID" | jq -r .state)
+echo "before: hangard_pid=$PID_BEFORE state=$STATE_BEFORE"
+
+# 4. Restart hangard. In dev (manual cargo run) send SIGTERM and restart it
+#    in its tmux pane; in prod use: systemctl --user restart hangar
+kill -TERM "$PID_BEFORE"
+# ...wait for the dev pane to relaunch hangard, or `systemctl --user restart hangar`
+sleep 5
+
+# 5. Post-restart state.
+PID_AFTER=$(pgrep -f 'target/release/hangard' | head -1)
+STATE_AFTER=$(curl -s "http://localhost:3000/api/v1/sessions/$SID" | jq -r .state)
+CONNECTED=$(curl -s http://localhost:3000/api/v1/health | jq -r .supervisor_connected)
+echo "after:  hangard_pid=$PID_AFTER state=$STATE_AFTER supervisor_connected=$CONNECTED"
+
+# 6. Assertions.
+test "$PID_AFTER"    != "$PID_BEFORE"    && echo "OK: hangard pid changed"
+test "$STATE_AFTER"  =  "running"        && echo "OK: session still running"
+test "$CONNECTED"    =  "true"           && echo "OK: supervisor reconnected"
+
+# 7. Prove the PTY still accepts writes.
+curl -sS -X POST "http://localhost:3000/api/v1/sessions/$SID/prompt" \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"cat /tmp/hangar-smoke.txt\n"}' >/dev/null
+```
+
+Expected result: `hangard_pid` differs before/after, `state=running` both
+before and after, `supervisor_connected=true` after.
+
+If `state` flips to `exited` after restart, do **not** fix in-place —
+file a detailed bug on #38 with: the two state payloads, `hangard` logs
+spanning the restart, and `journalctl --user -u hangar-supervisor` for
+the same window.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `supervisor_connected: false` in health | `hangar-supervisor` not running, or socket path mismatch | `systemctl --user status hangar-supervisor`; confirm socket at `~/.local/state/hangar/supervisor.sock` |
+| `Failed to connect to bus: No medium found` | `XDG_RUNTIME_DIR` unset in this shell | `export XDG_RUNTIME_DIR=/run/user/$(id -u); export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus` |
+| Unit stops when you log out | no user lingering | `loginctl enable-linger $(whoami)` |
+| `hangar.service` fails with `Address already in use` | a manual `cargo run hangard` is holding port 3000 | stop the manual one, or keep `hangar.service` disabled on dev boxes |
+| Sessions flip to `exited` after restart | supervisor reparenting or fd-passing regression | see #36/#38 — capture logs, do not retry blindly |

--- a/systemd/hangar-supervisor.service
+++ b/systemd/hangar-supervisor.service
@@ -4,8 +4,7 @@ Before=hangar.service
 
 [Service]
 Type=simple
-User=george
-ExecStart=/home/george/Documents/hangar/backend/target/release/hangar-supervisor
+ExecStart=%h/Documents/hangar/backend/target/release/hangar-supervisor
 Environment=RUST_LOG=info
 Restart=always
 RestartSec=1
@@ -14,4 +13,4 @@ RestartSec=1
 KillMode=process
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/systemd/hangar.service
+++ b/systemd/hangar.service
@@ -5,13 +5,12 @@ Requires=hangar-supervisor.service
 
 [Service]
 Type=simple
-User=george
-WorkingDirectory=/home/george/Documents/hangar
-ExecStart=/home/george/Documents/hangar/backend/target/release/hangard
+WorkingDirectory=%h/Documents/hangar
+ExecStart=%h/Documents/hangar/backend/target/release/hangard
 Environment=HANGAR_PORT=3000
 Environment=RUST_LOG=info
 Restart=on-failure
 RestartSec=3
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Rolls out the Phase 2.3 `hangar-supervisor` daemon end-to-end: systemd user unit installed + running on the box, install runbook, env-var overrides for ephemeral instances, automated integration test, and ADR / phase-doc close-out.

Closes #8, #35, #36, #37, #38, #39.

## Summary
- **#35 install** — systemd user unit installed + enabled on the dev box; `GET /api/v1/health` → `supervisor_connected: true`. Conversion from system→user unit (`%h` paths, `default.target`, drop `User=george`). Runbook at [`docs/runbook/supervisor-install.md`](docs/runbook/supervisor-install.md).
- **#36 smoke** — shell session created, hangard SIGTERMed + relaunched, PTY accepts writes post-restart. Stamp file carries both PRE_RESTART and POST_RESTART lines — proves the supervisor re-passed the master fd via `SCM_RIGHTS`. Evidence captured inline in the runbook.
- **#37 integration test** — `backend/tests/supervisor_restart.rs`: spawns real supervisor + hangard on an ephemeral socket / state dir / TCP port, performs full kill-and-replace, asserts same PTY is still writable after the restart. Green locally.
- **env-var overrides** — new `HANGAR_STATE_DIR` + `HANGAR_SUPERVISOR_SOCK` knobs (defaults unchanged on Linux). Single source of truth in `supervisor_protocol::hangar_state_dir()` used by both hangard and the supervisor binary.
- **#38** — nothing surfaced by the smoke or integration runs. Placeholder closed.
- **#39 close-out** — ADR 0010 status → `Accepted + Implemented` with implementation notes; phase-02 doc flags the rollout date and adds an Implementation notes section.

## Commits (squash-ready)
- `d199e41` chore: install hangar-supervisor systemd user unit
- `ddff819` docs(runbook): add supervisor install + survive-restart verification
- `1f682b9` docs(runbook): fix smoke script + record #36 evidence
- `718d4f3` feat(backend): env-var overrides for supervisor socket + state dir
- `52dba23` test(backend): supervisor_restart integration test (#37)
- `009cecb` docs: mark ADR 0010 Accepted + Implemented; note supervisor rollout in phase 02

## Test plan
- [x] `cargo test --target-dir /tmp/hangar-ephemeral --test supervisor_restart` — 1/1 passed locally
- [x] `cargo test --target-dir /tmp/hangar-ephemeral --test supervisor_test` — 4/4 passed (no regression from env-var change)
- [x] `cargo test --target-dir /tmp/hangar-ephemeral --test integration_test` — 10/10 passed
- [x] `cargo test --target-dir /tmp/hangar-ephemeral --test ringbuf_test` — 7/7 passed
- [x] `cargo test --target-dir /tmp/hangar-ephemeral --test push_integration` — 2/2 passed
- [x] Manual smoke (#36) on box: `hangard` pid 286405 → 290669 across SIGTERM + relaunch; session `01KPGS36...` state stayed `idle`; `/tmp/hangar-smoke.txt` contains PRE_RESTART + POST_RESTART lines
- [x] `systemctl --user is-enabled hangar-supervisor` → `enabled`; `is-active` → `active`; `ls ~/.local/state/hangar/supervisor.sock` → socket present

## CI caveat (pre-existing, not from this PR)
CI has been failing on `main` since #34 due to (a) `backend/tests/claude_code_driver_test.rs` missing a match arm for the new `AgentEvent::CostUpdated` variant, (b) unused `PROMPT_RE` static tripping `clippy -D warnings`, (c) minor rustfmt drift in `backend/src/api/sessions.rs` + `backend/src/drivers/mod.rs`. This PR intentionally does not bundle those fixes (scope). I'll clean them up in a dedicated follow-up — see the #38 close-out comment for details.