### PR TITLE
fix: backend CI drift from #34

### DIFF
--- a/backend/src/api/sessions.rs
+++ b/backend/src/api/sessions.rs
@@ -189,8 +189,7 @@ pub async fn create_session(
 
     // Wire up CC hook channel so cc_hook_socket can deliver hook bodies to the driver.
     {
-        let (oob_tx, mut oob_rx) =
-            tokio::sync::mpsc::channel::<crate::drivers::OobMessage>(64);
+        let (oob_tx, mut oob_rx) = tokio::sync::mpsc::channel::<crate::drivers::OobMessage>(64);
         state
             .hook_channels
             .lock()

--- a/backend/src/drivers/claude_code.rs
+++ b/backend/src/drivers/claude_code.rs
@@ -21,7 +21,6 @@ static THINK_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^thinking\.{0,3}$|^<thinking>").unwrap());
 static TOOL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[⏺●•]\s+(\w+)\s*[\(\{]?(.*)").unwrap());
-static PROMPT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[❯>]\s").unwrap());
 static ERR_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^(?:error|api error|rate limit)[:\s](.+)").unwrap());
 // UNVERIFIED — needs fixture capture from real Claude Code session

--- a/backend/src/drivers/mod.rs
+++ b/backend/src/drivers/mod.rs
@@ -2,17 +2,15 @@ pub mod claude_code;
 /// Claude TUI status-line scraper. Parses "CTX 3% 30k $0.11 | ... | claude-opus-4-7[1m] | ..."
 /// shared across drivers (both claude_code sessions and shells that host a claude process).
 pub mod status_scraper {
-    use std::sync::LazyLock;
-    use regex::Regex;
     use crate::events::AgentEvent;
     use crate::util;
+    use regex::Regex;
+    use std::sync::LazyLock;
 
-    static STATUS_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"CTX\s*(\d+)%\s*(\d+)k\s*\$([\d.]+)").unwrap()
-    });
-    static STATUS_MODEL_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"\|\s+(claude-[A-Za-z0-9\-]+(?:\[\d+m?\])?)\s+\|").unwrap()
-    });
+    static STATUS_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"CTX\s*(\d+)%\s*(\d+)k\s*\$([\d.]+)").unwrap());
+    static STATUS_MODEL_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\|\s+(claude-[A-Za-z0-9\-]+(?:\[\d+m?\])?)\s+\|").unwrap());
 
     // Claude TUI cursor-positions the bullet glyph away from the tool name in the raw
     // byte stream, so anchor on known tool-name tokens instead.

--- a/backend/tests/claude_code_driver_test.rs
+++ b/backend/tests/claude_code_driver_test.rs
@@ -32,6 +32,7 @@ fn variant_name(e: &AgentEvent) -> &'static str {
         AgentEvent::ContextWindowSizeChanged { .. } => "context_window_size_changed",
         AgentEvent::SandboxStateChanged { .. } => "sandbox_state_changed",
         AgentEvent::SandboxMerged { .. } => "sandbox_merged",
+        AgentEvent::CostUpdated { .. } => "cost_updated",
     }
 }
 
@@ -202,12 +203,18 @@ fn test_spawn_cfg_builds_command() {
     };
     let cfg = d.spawn_cfg(&req).unwrap();
     assert!(cfg.command.contains(&"claude".to_string()));
-    assert!(cfg.command.contains(&"--config-dir".to_string()));
+    // CC driver switched from --config-dir to --settings in #33 ("drop phantom flags").
+    assert!(
+        cfg.command.contains(&"--settings".to_string()),
+        "expected --settings in command, got {:?}",
+        cfg.command
+    );
     assert!(!cfg.temp_files.is_empty());
 
-    // Verify settings.json was written
-    let settings_path = cfg.temp_files[0].join("settings.json");
-    let content = std::fs::read_to_string(&settings_path).unwrap();
+    // Verify hangar-settings.json was written with the hook config.
+    let settings_path = cfg.temp_files[0].join("hangar-settings.json");
+    let content = std::fs::read_to_string(&settings_path)
+        .unwrap_or_else(|e| panic!("read {:?}: {}", settings_path, e));
     let v: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(v["hooks"]["PreToolUse"].is_array());
     assert!(v["hooks"]["Stop"].is_array());

--- a/backend/tests/fixtures/cc_transcripts/turn_empty_response.expected.json
+++ b/backend/tests/fixtures/cc_transcripts/turn_empty_response.expected.json
@@ -1,1 +1,1 @@
-[{"type":"turn_started","role":"user"}]
+[]

--- a/backend/tests/fixtures/cc_transcripts/turn_multi_tool.expected.json
+++ b/backend/tests/fixtures/cc_transcripts/turn_multi_tool.expected.json
@@ -1,1 +1,1 @@
-[{"type":"turn_started","role":"user"},{"type":"tool_call_started","tool":"Read"},{"type":"tool_call_finished"}]
+[{"type":"tool_call_started","tool":"Read"},{"type":"tool_call_finished"}]

--- a/backend/tests/fixtures/cc_transcripts/turn_simple_qa.expected.json
+++ b/backend/tests/fixtures/cc_transcripts/turn_simple_qa.expected.json
@@ -1,1 +1,1 @@
-[{"type":"turn_started","role":"user"}]
+[]


### PR DESCRIPTION
Restores green CI on \`main\`, which has been failing on every push since #34 (2026-04-18). The five problems were stacked behind a compile error — fixing the compile surfaced the rest.

## Summary
1. \`tests/claude_code_driver_test.rs\` — non-exhaustive match on \`AgentEvent\`; add the missing \`CostUpdated\` arm introduced by #34.
2. \`src/drivers/claude_code.rs\` — delete unused \`PROMPT_RE\` static (\`cargo clippy --all-targets -- -D warnings\`).
3. \`src/api/sessions.rs\`, \`src/drivers/mod.rs\` — rustfmt drift from #34 (\`cargo fmt --all -- --check\`).
4. \`test_spawn_cfg_builds_command\` — spawn command switched to \`--settings <path>\` + filename \`hangar-settings.json\` in #33; update the assertions.
5. \`test_fixture_classification_rate\` (threshold 95%, was at 85%) — three \`turn_*\` fixtures expected \`turn_started\` from \`on_bytes()\`, but \`TurnStarted\` only comes from hook-driven \`on_oob\` (UserPromptSubmit/SessionStart). Trim the \`turn_started\` entries from the three expected JSONs.

No production-code behavior changes beyond deleting the dead \`PROMPT_RE\` static.

## Test plan
- [x] \`cargo fmt --manifest-path backend/Cargo.toml -- --check\` — clean
- [x] \`cargo clippy --manifest-path backend/Cargo.toml --target-dir /tmp/hangar-ephemeral --all-targets -- -D warnings\` — clean
- [x] \`cargo build --manifest-path backend/Cargo.toml --target-dir /tmp/hangar-ephemeral --release\` — ok
- [x] \`cargo test --manifest-path backend/Cargo.toml --target-dir /tmp/hangar-ephemeral\` — lib 47/47 + all integration tests ok (2 ignored: PTY e2e requires real terminal)

Unblocks #43 (supervisor rollout). Merging this first, then rebasing / re-running CI on #43.