### PR TITLE
fix: API slug resolution + DELETE hard-remove + UI kill button (closes #27 #28)

### DIFF
--- a/backend/src/api/output.rs
+++ b/backend/src/api/output.rs
@@ -6,6 +6,7 @@ use axum::{
 use serde::Deserialize;
 use serde_json::json;
 
+use crate::api::resolve_session;
 use crate::{ringbuf::RingBuf, AppState};
 
 #[derive(Deserialize)]
@@ -19,7 +20,13 @@ pub async fn get_output(
     Query(params): Query<OutputQuery>,
     State(state): State<AppState>,
 ) -> Response {
-    let ring_path = state.ring_dir.join(&id).join("output.bin");
+    let session = match resolve_session(&state, &id).await {
+        Ok(s) => s,
+        Err(status) => return (status, "session not found").into_response(),
+    };
+    let ulid = session.id.to_string();
+
+    let ring_path = state.ring_dir.join(&ulid).join("output.bin");
 
     if !ring_path.exists() {
         return (StatusCode::NOT_FOUND, "session output not found").into_response();

--- a/backend/src/api/resize.rs
+++ b/backend/src/api/resize.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use serde::Deserialize;
 
+use crate::api::resolve_session;
 use crate::events::Event;
 use crate::AppState;
 
@@ -19,8 +20,11 @@ pub async fn resize_session(
     Path(id): Path<String>,
     Json(body): Json<ResizeRequest>,
 ) -> Result<StatusCode, StatusCode> {
+    let session = resolve_session(&state, &id).await?;
+    let ulid = session.id.to_string();
+
     let sessions = state.sessions.read().unwrap();
-    let active = sessions.get(&id).ok_or(StatusCode::NOT_FOUND)?;
+    let active = sessions.get(&ulid).ok_or(StatusCode::NOT_FOUND)?;
 
     active
         .master
@@ -28,7 +32,7 @@ pub async fn resize_session(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     state.event_bus.send(
-        id,
+        ulid,
         Event::Resized {
             cols: body.cols,
             rows: body.rows,

--- a/backend/src/api/sessions.rs
+++ b/backend/src/api/sessions.rs
@@ -313,11 +313,13 @@ pub async fn delete_session(
     let session = resolve_session(&state, &id).await?;
     let ulid = session.id.to_string();
 
+    // 1. Kill PTY: remove from active map and ask the driver to shut down
+    //    cleanly. Driver shutdown writes a termination sequence via the
+    //    master side; the read loop will then see EOF.
     let active = {
         let mut sessions = state.sessions.write().unwrap();
         sessions.remove(&ulid)
     };
-
     if let Some(active) = active {
         let writer_clone = std::sync::Arc::clone(&active.writer);
         let mut handle = PtyHandle::new(Box::new(WriterLock(writer_clone)));
@@ -325,24 +327,47 @@ pub async fn delete_session(
             .driver
             .lock()
             .unwrap()
-            .shutdown(&mut handle, Duration::from_secs(5));
+            .shutdown(&mut handle, Duration::from_secs(2));
     }
 
+    // 2. If held by supervisor, force-kill the child so the PID is reaped
+    //    regardless of whether the driver's graceful shutdown succeeded.
     if let Some(ref sup) = state.supervisor {
-        let _ = sup.kill(&ulid, libc::SIGTERM).await;
+        let _ = sup.kill(&ulid, libc::SIGKILL).await;
     }
 
-    Session::update_state(state.db.pool(), &session.id, SessionState::Exited)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    // 3. Stop any sandbox container associated with the session.
+    if session.sandbox.is_some() {
+        if let Some(ref mgr) = state.sandbox_manager {
+            if let Err(e) = mgr.stop_container(&session.id).await {
+                tracing::warn!("stop_container during delete failed (non-fatal): {e}");
+            }
+            let _ = mgr.cleanup_overlay_dirs(&session.id);
+        }
+    }
 
-    state.event_bus.send(
-        ulid,
-        Event::StateChanged {
-            from: session.state,
-            to: SessionState::Exited,
-        },
-    );
+    // 4. Drop CC hook channel so the spawned hook-forwarder task exits.
+    state.hook_channels.lock().unwrap().remove(&ulid);
+
+    // 5. Delete DB rows (events + events_fts + sessions) in one transaction.
+    Session::delete(state.db.pool(), &session.id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Session::delete failed for {ulid}: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // 6. Remove the ring buffer directory on disk. Best-effort — if it is
+    //    missing, the row is already gone so the state is consistent.
+    let ring_session_dir = state.ring_dir.join(&ulid);
+    if ring_session_dir.exists() {
+        if let Err(e) = std::fs::remove_dir_all(&ring_session_dir) {
+            tracing::warn!(
+                "failed to remove ring dir {}: {e}",
+                ring_session_dir.display()
+            );
+        }
+    }
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,6 +1,11 @@
 use anyhow::Result;
-use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+    ConnectOptions, SqlitePool,
+};
 use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct Db {
@@ -21,10 +26,18 @@ impl Db {
             std::fs::create_dir_all(parent)?;
         }
 
+        // Per-connection options. A busy_timeout is essential: without it
+        // any concurrent writer (e.g. the event persister task) racing with
+        // a multi-statement write transaction (e.g. DELETE /sessions/:id)
+        // returns SQLITE_BUSY immediately.
         let url = format!("sqlite:{}?mode=rwc", db_path.display());
+        let connect_opts = SqliteConnectOptions::from_str(&url)?
+            .busy_timeout(Duration::from_secs(5))
+            .disable_statement_logging();
+
         let pool = SqlitePoolOptions::new()
             .max_connections(5)
-            .connect(&url)
+            .connect_with(connect_opts)
             .await?;
 
         sqlx::query("PRAGMA journal_mode=WAL")

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -226,29 +226,74 @@ impl Session {
         Ok(())
     }
 
-    /// Hard-delete a session and all events. Removes FTS rows first, then
-    /// events (FK), then the sessions row itself. Returns true if a row was
-    /// removed from `sessions`.
+    /// Hard-delete a session and all events. Removes FTS rows via the FTS5
+    /// 'delete' command (external-content tables cannot be updated via plain
+    /// DELETE), then removes events (FK), then the sessions row itself.
+    /// Returns true if a row was removed from `sessions`.
+    ///
+    /// Uses `BEGIN IMMEDIATE` to acquire the write lock up-front so the
+    /// connection's configured `busy_timeout` governs the contention
+    /// window — otherwise sqlx's default deferred transaction only notices
+    /// the concurrent writer on its first statement, after our inner
+    /// queries have already been submitted.
     pub async fn delete(pool: &SqlitePool, id: &SessionId) -> Result<bool> {
         let id_str = id.to_string();
-        let mut tx = pool.begin().await?;
+        let mut conn = pool.acquire().await?;
 
-        sqlx::query("DELETE FROM events_fts WHERE session_id = ?")
-            .bind(&id_str)
-            .execute(&mut *tx)
-            .await?;
+        sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+        let result = Self::delete_inner(&mut conn, &id_str).await;
+        match result {
+            Ok(deleted) => {
+                sqlx::query("COMMIT").execute(&mut *conn).await?;
+                Ok(deleted)
+            }
+            Err(e) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn delete_inner(
+        conn: &mut sqlx::SqliteConnection,
+        id_str: &str,
+    ) -> Result<bool> {
+        // events_fts is external-content (content='events'). A direct
+        // `DELETE FROM events_fts` yields SQLITE_CORRUPT_VTAB, so we emit
+        // the FTS5 'delete' command for each row belonging to this session.
+        // Rows with no body_text have no FTS entry to remove.
+        let fts_rows: Vec<(i64, Option<String>, String, String)> = sqlx::query_as(
+            "SELECT id, body_text, session_id, kind FROM events WHERE session_id = ?",
+        )
+        .bind(id_str)
+        .fetch_all(&mut *conn)
+        .await?;
+
+        for (rowid, body_text, sid, kind) in &fts_rows {
+            if let Some(body) = body_text {
+                sqlx::query(
+                    "INSERT INTO events_fts(events_fts, rowid, body_text, session_id, kind) \
+                     VALUES ('delete', ?, ?, ?, ?)",
+                )
+                .bind(rowid)
+                .bind(body)
+                .bind(sid)
+                .bind(kind)
+                .execute(&mut *conn)
+                .await?;
+            }
+        }
 
         sqlx::query("DELETE FROM events WHERE session_id = ?")
-            .bind(&id_str)
-            .execute(&mut *tx)
+            .bind(id_str)
+            .execute(&mut *conn)
             .await?;
 
         let res = sqlx::query("DELETE FROM sessions WHERE id = ?")
-            .bind(&id_str)
-            .execute(&mut *tx)
+            .bind(id_str)
+            .execute(&mut *conn)
             .await?;
 
-        tx.commit().await?;
         Ok(res.rows_affected() > 0)
     }
 

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -226,6 +226,32 @@ impl Session {
         Ok(())
     }
 
+    /// Hard-delete a session and all events. Removes FTS rows first, then
+    /// events (FK), then the sessions row itself. Returns true if a row was
+    /// removed from `sessions`.
+    pub async fn delete(pool: &SqlitePool, id: &SessionId) -> Result<bool> {
+        let id_str = id.to_string();
+        let mut tx = pool.begin().await?;
+
+        sqlx::query("DELETE FROM events_fts WHERE session_id = ?")
+            .bind(&id_str)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("DELETE FROM events WHERE session_id = ?")
+            .bind(&id_str)
+            .execute(&mut *tx)
+            .await?;
+
+        let res = sqlx::query("DELETE FROM sessions WHERE id = ?")
+            .bind(&id_str)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(res.rows_affected() > 0)
+    }
+
     pub async fn update_sandbox(pool: &SqlitePool, id: &str, status: &SandboxStatus) -> Result<()> {
         let sandbox_json = serde_json::to_string(status)?;
         let now = std::time::SystemTime::now()

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -254,10 +254,7 @@ impl Session {
         }
     }
 
-    async fn delete_inner(
-        conn: &mut sqlx::SqliteConnection,
-        id_str: &str,
-    ) -> Result<bool> {
+    async fn delete_inner(conn: &mut sqlx::SqliteConnection, id_str: &str) -> Result<bool> {
         // events_fts is external-content (content='events'). A direct
         // `DELETE FROM events_fts` yields SQLITE_CORRUPT_VTAB, so we emit
         // the FTS5 'delete' command for each row belonging to this session.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -71,6 +71,12 @@ export async function resizeSession(id: string, cols: number, rows: number): Pro
 	);
 }
 
+export async function deleteSession(id: string): Promise<void> {
+	await checkOk(
+		await fetch(`/api/v1/sessions/${id}`, { method: 'DELETE' })
+	);
+}
+
 export function normalizeLabels(raw: unknown): LabelEntry[] {
 	if (raw === null || raw === undefined) return [];
 	if (Array.isArray(raw)) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -63,6 +63,10 @@ export const sessionsStore = {
 		return sessions.find((s) => s.id === id);
 	},
 
+	removeSession(id: string) {
+		sessions = sessions.filter((s) => s.id !== id);
+	},
+
 	toggleLabelFilter(label: LabelEntry) {
 		const idx = selectedLabels.findIndex((l) => l.key === label.key && l.value === label.value);
 		if (idx >= 0) {

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -3,7 +3,7 @@
 	import type { Session } from '$lib/types';
 	import { sessionsStore } from '$lib/stores/sessions.svelte';
 	import { eventsStore } from '$lib/stores/events.svelte';
-	import { kindLabel, kindIcon } from '$lib/api';
+	import { kindLabel, kindIcon, deleteSession, ApiError } from '$lib/api';
 	import { stateColor } from '$lib/utils';
 	import InsightsPanel from '$lib/components/InsightsPanel.svelte';
 	import TerminalView from '$lib/components/TerminalView.svelte';
@@ -12,6 +12,10 @@
 	let { data }: { data: { session: Session } } = $props();
 
 	let session = $derived(sessionsStore.getSessionById(data.session.id) ?? data.session);
+
+	let confirmOpen = $state(false);
+	let killing = $state(false);
+	let killError = $state<string | null>(null);
 
 	$effect(() => {
 		const id = data.session.id;
@@ -27,6 +31,36 @@
 			case 'bot': return '🤖';
 			case 'binary': return '⬜';
 			default: return '•';
+		}
+	}
+
+	function openConfirm() {
+		killError = null;
+		confirmOpen = true;
+	}
+
+	function cancelConfirm() {
+		if (killing) return;
+		confirmOpen = false;
+	}
+
+	async function confirmKill() {
+		if (killing) return;
+		killing = true;
+		killError = null;
+		try {
+			await deleteSession(session.id);
+			// Nudge the sessions store so dashboard does not show a stale tile.
+			sessionsStore.removeSession?.(session.id);
+			await goto('/');
+		} catch (err) {
+			killError =
+				err instanceof ApiError
+					? `${err.status}: ${err.body || err.message}`
+					: err instanceof Error
+						? err.message
+						: 'Unknown error';
+			killing = false;
 		}
 	}
 </script>
@@ -48,7 +82,38 @@
 		{#if session.agent_meta?.model}
 			<span class="model-name mono">{session.agent_meta.model}</span>
 		{/if}
+		<button
+			class="kill-btn"
+			type="button"
+			title="Kill and remove this session"
+			onclick={openConfirm}
+		>
+			✕ Kill
+		</button>
 	</div>
+
+	{#if confirmOpen}
+		<div class="modal-backdrop" onclick={cancelConfirm} role="presentation">
+			<div class="modal" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="kill-title">
+				<h2 id="kill-title">Kill session <code class="mono">{session.slug}</code>?</h2>
+				<p>
+					This will terminate the underlying process and permanently remove the session,
+					its event history, and its terminal ring buffer. This cannot be undone.
+				</p>
+				{#if killError}
+					<p class="modal-error">Error: {killError}</p>
+				{/if}
+				<div class="modal-actions">
+					<button type="button" class="btn-secondary" onclick={cancelConfirm} disabled={killing}>
+						Cancel
+					</button>
+					<button type="button" class="btn-danger" onclick={confirmKill} disabled={killing}>
+						{killing ? 'Killing…' : 'Kill session'}
+					</button>
+				</div>
+			</div>
+		</div>
+	{/if}
 
 	{#if eventsStore.awaitingPermission}
 		<div class="permission-banner">
@@ -227,5 +292,97 @@
 	.sandbox-error {
 		font-size: 0.8rem;
 		color: #f44336;
+	}
+
+	.kill-btn {
+		margin-left: 8px;
+		background: transparent;
+		color: #f44336;
+		border: 1px solid rgba(244, 67, 54, 0.5);
+		border-radius: var(--radius);
+		padding: 3px 10px;
+		font-size: 0.8rem;
+		cursor: pointer;
+	}
+
+	.kill-btn:hover {
+		background: rgba(244, 67, 54, 0.12);
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.55);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.modal {
+		background: var(--surface, var(--bg));
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: 20px 22px;
+		max-width: 440px;
+		width: calc(100% - 32px);
+		box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+	}
+
+	.modal h2 {
+		font-size: 1rem;
+		margin: 0 0 10px 0;
+		color: var(--text);
+	}
+
+	.modal p {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		margin: 0 0 14px 0;
+		line-height: 1.4;
+	}
+
+	.modal-error {
+		color: #f44336;
+	}
+
+	.modal-actions {
+		display: flex;
+		gap: 10px;
+		justify-content: flex-end;
+	}
+
+	.btn-secondary,
+	.btn-danger {
+		border-radius: var(--radius);
+		padding: 6px 14px;
+		font-size: 0.85rem;
+		cursor: pointer;
+		border: 1px solid var(--border);
+	}
+
+	.btn-secondary {
+		background: transparent;
+		color: var(--text);
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background: rgba(255, 255, 255, 0.05);
+	}
+
+	.btn-danger {
+		background: #f44336;
+		color: #fff;
+		border-color: #f44336;
+	}
+
+	.btn-danger:hover:not(:disabled) {
+		background: #e53935;
+	}
+
+	.btn-secondary:disabled,
+	.btn-danger:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
 	}
 </style>

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -93,8 +93,21 @@
 	</div>
 
 	{#if confirmOpen}
-		<div class="modal-backdrop" onclick={cancelConfirm} role="presentation">
-			<div class="modal" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="kill-title">
+		<div
+			class="modal-backdrop"
+			onclick={cancelConfirm}
+			onkeydown={(e) => e.key === 'Escape' && cancelConfirm()}
+			role="presentation"
+		>
+			<div
+				class="modal"
+				onclick={(e) => e.stopPropagation()}
+				onkeydown={(e) => e.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="kill-title"
+				tabindex={-1}
+			>
 				<h2 id="kill-title">Kill session <code class="mono">{session.slug}</code>?</h2>
 				<p>
 					This will terminate the underlying process and permanently remove the session,


### PR DESCRIPTION
Fixes two related issues in one PR.

## #27 — API slug/ULID parity

`POST /api/v1/sessions/:id/resize` and `GET /api/v1/sessions/:id/output` only resolved ULIDs — a slug returned 404. `/key` and `/prompt` already went through the `resolve_session()` helper in `backend/src/api/mod.rs`; the two laggards now do the same.

### Manual QA against a fresh hangard on :3001

```
$ curl -s -X POST localhost:3001/api/v1/sessions \
    -H 'Content-Type: application/json' \
    -d '{"slug":"parity-test","kind":{"type":"shell"}}'
{"id":"01KPH0BX8HWSWTNW6Q64Y0MYDR","slug":"parity-test", ...}

# Before (on e4cc63c):
$ curl -si localhost:3001/api/v1/sessions/parity-test/output
HTTP/1.1 404 Not Found

$ curl -si -X POST localhost:3001/api/v1/sessions/parity-test/resize \
    -H 'Content-Type: application/json' -d '{"cols":120,"rows":40}'
HTTP/1.1 404 Not Found

# After:
$ curl -si localhost:3001/api/v1/sessions/parity-test/output?len=128
HTTP/1.1 200 OK
content-type: application/octet-stream

$ curl -si -X POST localhost:3001/api/v1/sessions/parity-test/resize \
    -H 'Content-Type: application/json' -d '{"cols":120,"rows":40}'
HTTP/1.1 200 OK
```

## #28 — DELETE hard-removes + UI kill control

Previously `DELETE /api/v1/sessions/:id` returned 204 but only flipped state to `exited` — the row, event history, ring buffer, and supervisor stub all lingered, and a subsequent GET still returned 200.

### Backend (`backend/src/api/sessions.rs`, `backend/src/session.rs`, `backend/src/db.rs`)

Delete ordering now:
1. Kill PTY: remove from active sessions map + `driver.shutdown(...)` (graceful, 2s).
2. `supervisor.kill(SIGKILL)` if held by supervisor so the child PID is reaped regardless of the graceful path.
3. `SandboxManager::stop_container` + `cleanup_overlay_dirs` if a sandbox is attached.
4. Drop the CC hook channel so the hook-forwarder task exits.
5. `Session::delete` — single `BEGIN IMMEDIATE` transaction that removes rows from `events_fts` (via the FTS5 `delete` command, since external-content fts5 does not support plain DELETE), `events`, and `sessions`.
6. `remove_dir_all` on the ring-buffer directory.

Two follow-up fixes surfaced under concurrent load and are in the second backend commit:
- External-content FTS5 returned `SQLITE_CORRUPT_VTAB` on direct DELETE — switched to the documented `INSERT INTO events_fts(events_fts, rowid, ...) VALUES('delete', ...)` form per row.
- With WAL + no busy_timeout the event-persister task racing with the multi-statement transaction returned `SQLITE_BUSY` immediately. Added `busy_timeout = 5s` via `SqliteConnectOptions` and wrapped the delete in explicit `BEGIN IMMEDIATE` so the write lock is acquired up-front under that timeout.

### Frontend (`frontend/src/routes/session/[id]/+page.svelte`, `frontend/src/lib/api.ts`, `frontend/src/lib/stores/sessions.svelte.ts`)

- New `deleteSession(id)` helper in `api.ts`.
- Session detail page gets a red **✕ Kill** button in the header.
- Clicking it opens a confirmation modal: _"This will terminate the underlying process and permanently remove the session, its event history, and its terminal ring buffer. This cannot be undone."_
- On confirm: `DELETE /api/v1/sessions/:id` → `sessionsStore.removeSession(id)` (so the dashboard grid drops the tile without waiting for the next poll) → `goto('/')`.
- Cancel is disabled while the request is in flight; backend errors are surfaced in the modal so the user can retry.

### Manual QA

```
$ curl -si -X DELETE localhost:3001/api/v1/sessions/parity-test
HTTP/1.1 204 No Content

$ curl -si localhost:3001/api/v1/sessions/01KPH0BX8HWSWTNW6Q64Y0MYDR
HTTP/1.1 404 Not Found

$ curl -si localhost:3001/api/v1/sessions/parity-test
HTTP/1.1 404 Not Found

$ curl -s localhost:3001/api/v1/sessions
[]

$ ls /tmp/hangar-test-state/sessions/
# (empty)
```

## Build

Built with the ephemeral target as requested:

```
cargo build --release --manifest-path backend/Cargo.toml \
  --target-dir /tmp/hangar-ephemeral --bin hangard
    Finished \`release\` profile [optimized] target(s)
```

The running production hangard on :3000 was **not** restarted. QA was done against a disposable instance on :3001 with `HANGAR_STATE_DIR=/tmp/hangar-test-state`.

Closes #27
Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session deletion capability with a "Kill" button on the session detail page.
  * Implemented confirmation modal for session deletion operations.

* **Refactor**
  * Enhanced session cleanup and shutdown process with improved resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->