### PR TITLE
feat(ui): collapsible sidebar (closes #41)

### DIFF
--- a/frontend/src/lib/stores/sidebar.svelte.ts
+++ b/frontend/src/lib/stores/sidebar.svelte.ts
@@ -1,0 +1,48 @@
+const DASHBOARD_KEY = 'hangar.sidebar.dashboard.collapsed';
+const SESSION_KEY = 'hangar.sidebar.session.collapsed';
+
+function readBool(key: string): boolean {
+	try {
+		if (typeof localStorage === 'undefined') return false;
+		return localStorage.getItem(key) === '1';
+	} catch {
+		return false;
+	}
+}
+
+function writeBool(key: string, val: boolean) {
+	try {
+		if (typeof localStorage === 'undefined') return;
+		localStorage.setItem(key, val ? '1' : '0');
+	} catch {
+		// ignore (SSR / privacy mode)
+	}
+}
+
+let dashboardCollapsed = $state(readBool(DASHBOARD_KEY));
+let sessionCollapsed = $state(readBool(SESSION_KEY));
+
+export const sidebarStore = {
+	get dashboardCollapsed() {
+		return dashboardCollapsed;
+	},
+	get sessionCollapsed() {
+		return sessionCollapsed;
+	},
+	toggleDashboard() {
+		dashboardCollapsed = !dashboardCollapsed;
+		writeBool(DASHBOARD_KEY, dashboardCollapsed);
+	},
+	toggleSession() {
+		sessionCollapsed = !sessionCollapsed;
+		writeBool(SESSION_KEY, sessionCollapsed);
+	},
+	setDashboard(val: boolean) {
+		dashboardCollapsed = val;
+		writeBool(DASHBOARD_KEY, val);
+	},
+	setSession(val: boolean) {
+		sessionCollapsed = val;
+		writeBool(SESSION_KEY, val);
+	},
+};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -17,6 +17,21 @@
 		return () => sessionsStore.stopPolling();
 	});
 
+	$effect(() => {
+		function onKey(e: KeyboardEvent) {
+			if (!e.ctrlKey || e.key !== '\\') return;
+			e.preventDefault();
+			const path = $page.url.pathname;
+			if (path.startsWith('/session/')) {
+				sidebarStore.toggleSession();
+			} else {
+				sidebarStore.toggleDashboard();
+			}
+		}
+		document.addEventListener('keydown', onKey);
+		return () => document.removeEventListener('keydown', onKey);
+	});
+
 	function handleCreated(_session: Session) {
 		spawnOpen = false;
 	}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import { page } from '$app/stores';
 	import { sessionsStore } from '$lib/stores/sessions.svelte';
+	import { sidebarStore } from '$lib/stores/sidebar.svelte';
 	import LabelSidebar from '$lib/components/LabelSidebar.svelte';
 	import SpawnModal from '$lib/components/SpawnModal.svelte';
 	import type { Session } from '$lib/types';
@@ -9,7 +10,7 @@
 	let { children } = $props();
 
 	let spawnOpen = $state(false);
-	let sidebarOpen = $state(true);
+	let collapsed = $derived(sidebarStore.dashboardCollapsed);
 
 	$effect(() => {
 		sessionsStore.startPolling();
@@ -25,25 +26,30 @@
 	<title>Hangar</title>
 </svelte:head>
 
-<div class="app-shell" class:sidebar-collapsed={!sidebarOpen}>
+<div class="app-shell" class:sidebar-collapsed={collapsed}>
 	<aside class="sidebar">
-		<nav class="nav-links">
-			<a href="/" class="nav-link" class:active={$page.url.pathname === '/'}>Sessions</a>
-			<a href="/logs" class="nav-link" class:active={$page.url.pathname === '/logs'}>Logs</a>
-		</nav>
-		<LabelSidebar />
+		<div class="sidebar-header">
+			<button
+				class="collapse-btn"
+				onclick={() => sidebarStore.toggleDashboard()}
+				aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+				title={collapsed ? 'Expand (Ctrl+\\)' : 'Collapse (Ctrl+\\)'}
+			>
+				{collapsed ? '»' : '«'}
+			</button>
+		</div>
+		{#if !collapsed}
+			<nav class="nav-links">
+				<a href="/" class="nav-link" class:active={$page.url.pathname === '/'}>Sessions</a>
+				<a href="/logs" class="nav-link" class:active={$page.url.pathname === '/logs'}>Logs</a>
+			</nav>
+			<LabelSidebar />
+		{/if}
 	</aside>
 
 	<main class="content">
 		<header class="topbar">
 			<div class="topbar-left">
-				<button
-					class="hamburger"
-					onclick={() => (sidebarOpen = !sidebarOpen)}
-					aria-label="Toggle sidebar"
-				>
-					☰
-				</button>
 				<span class="logo">Hangar</span>
 			</div>
 			<button class="btn-primary" onclick={() => (spawnOpen = true)}>＋ New Session</button>
@@ -89,12 +95,39 @@
 		background: var(--bg-surface);
 		border-right: 1px solid var(--border);
 		overflow-y: auto;
-		transition: width 0.2s;
+		overflow-x: hidden;
+		transition: width 0.25s ease;
 	}
 
 	.app-shell.sidebar-collapsed .sidebar {
-		width: 0;
-		overflow: hidden;
+		width: 36px;
+	}
+
+	.sidebar-header {
+		display: flex;
+		justify-content: flex-end;
+		padding: 6px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.app-shell.sidebar-collapsed .sidebar-header {
+		justify-content: center;
+	}
+
+	.collapse-btn {
+		background: none;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 0.9rem;
+		line-height: 1;
+		padding: 2px 8px;
+	}
+
+	.collapse-btn:hover {
+		color: var(--text);
+		border-color: var(--accent);
 	}
 
 	.content {
@@ -119,19 +152,6 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
-	}
-
-	.hamburger {
-		background: none;
-		border: none;
-		color: var(--text-muted);
-		cursor: pointer;
-		font-size: 1rem;
-		padding: 4px;
-	}
-
-	.hamburger:hover {
-		color: var(--text);
 	}
 
 	.logo {
@@ -200,8 +220,8 @@
 		}
 
 		.app-shell.sidebar-collapsed .sidebar {
-			width: 200px;
-			transform: translateX(-200px);
+			width: 36px;
+			transform: translateX(0);
 		}
 	}
 </style>

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import type { Session } from '$lib/types';
 	import { sessionsStore } from '$lib/stores/sessions.svelte';
 	import { eventsStore } from '$lib/stores/events.svelte';
+	import { sidebarStore } from '$lib/stores/sidebar.svelte';
 	import { kindLabel, kindIcon, deleteSession, ApiError } from '$lib/api';
 	import { stateColor } from '$lib/utils';
 	import InsightsPanel from '$lib/components/InsightsPanel.svelte';
@@ -12,6 +13,7 @@
 	let { data }: { data: { session: Session } } = $props();
 
 	let session = $derived(sessionsStore.getSessionById(data.session.id) ?? data.session);
+	let insightsCollapsed = $derived(sidebarStore.sessionCollapsed);
 
 	let confirmOpen = $state(false);
 	let killing = $state(false);
@@ -151,9 +153,23 @@
 
 	<div class="session-body">
 		{#key session.id}
-			<div class="split">
+			<div class="split" class:insights-collapsed={insightsCollapsed}>
 				<div class="main-pane"><TerminalView {session} /></div>
-				<aside class="side-pane"><InsightsPanel /></aside>
+				<aside class="side-pane">
+					<div class="side-header">
+						<button
+							class="collapse-btn"
+							onclick={() => sidebarStore.toggleSession()}
+							aria-label={insightsCollapsed ? 'Expand insights' : 'Collapse insights'}
+							title={insightsCollapsed ? 'Expand (Ctrl+\\)' : 'Collapse (Ctrl+\\)'}
+						>
+							{insightsCollapsed ? '«' : '»'}
+						</button>
+					</div>
+					{#if !insightsCollapsed}
+						<div class="side-body"><InsightsPanel /></div>
+					{/if}
+				</aside>
 			</div>
 		{/key}
 	</div>
@@ -260,6 +276,11 @@
 		gap: 1px;
 		background: var(--border);
 		overflow: hidden;
+		transition: grid-template-columns 0.25s ease;
+	}
+
+	.split.insights-collapsed {
+		grid-template-columns: 1fr 36px;
 	}
 
 	.main-pane {
@@ -272,8 +293,44 @@
 
 	.side-pane {
 		overflow-y: auto;
+		overflow-x: hidden;
 		background: var(--surface, var(--bg));
 		border-left: 1px solid var(--border);
+		display: flex;
+		flex-direction: column;
+	}
+
+	.side-header {
+		display: flex;
+		justify-content: flex-start;
+		padding: 6px;
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.split.insights-collapsed .side-header {
+		justify-content: center;
+	}
+
+	.collapse-btn {
+		background: none;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 0.9rem;
+		line-height: 1;
+		padding: 2px 8px;
+	}
+
+	.collapse-btn:hover {
+		color: var(--text);
+		border-color: var(--accent);
+	}
+
+	.side-body {
+		flex: 1;
+		overflow-y: auto;
 	}
 
 	.sandbox-section {


### PR DESCRIPTION
Closes #41.

## Summary
- Dashboard + session-page sidebars are now collapsible
- Per-sidebar collapsed state persisted in localStorage
- `Ctrl+\` toggles whichever sidebar is visible on the current page
- Smooth width transition, slim rail remains when collapsed for the expand chevron

## Commits
- `10183ed` feat(ui): collapsible dashboard sidebar
- `af67ecc` feat(ui): collapsible session insights sidebar
- `c8e900a` feat(ui): Ctrl+\ toggles current-page sidebar

## Files
- `frontend/src/lib/stores/sidebar.svelte.ts` (new) — store + localStorage wrap
- `frontend/src/routes/+layout.svelte` — dashboard sidebar toggle
- `frontend/src/routes/session/[id]/+page.svelte` — session sidebar toggle

## Test plan
- [ ] Dashboard: chevron collapses/expands; refresh persists state
- [ ] Session page: same
- [ ] Ctrl+\\ toggles the sidebar on the current page
- [ ] No layout jank during transition

Note: minor merge likelihood on `src/routes/session/[id]/+page.svelte` against PR closing #27/#28 (being opened in parallel). Auto-merge should handle it; manual 2-min resolve if not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sidebar collapse and expand button for a cleaner, more focused interface.
  * Use Ctrl+\ keyboard shortcut to quickly toggle sidebar visibility.
  * Sidebar and insights panel collapse states now persist across page refreshes.
  * Session view now includes a collapsible insights panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->