### PR TITLE
fix: reap PTY zombies on DELETE (closes #51)

### DIFF
--- a/backend/src/api/sessions.rs
+++ b/backend/src/api/sessions.rs
@@ -328,10 +328,22 @@ pub async fn delete_session(
             .lock()
             .unwrap()
             .shutdown(&mut handle, Duration::from_secs(2));
+
+        // Reap the PTY child to prevent it lingering as a zombie parented
+        // to hangard. std::process::Child does not reap on drop, so we
+        // must explicitly kill + wait. Runs off the request path so the
+        // 204 response is not blocked by the grace window.
+        if let Some(child_arc) = active.child.clone() {
+            tokio::task::spawn_blocking(move || {
+                pty::reap_child(child_arc, Duration::from_millis(500));
+            });
+        }
     }
 
     // 2. If held by supervisor, force-kill the child so the PID is reaped
     //    regardless of whether the driver's graceful shutdown succeeded.
+    //    The supervisor owns the child PID and reaps via its own SIGCHLD
+    //    handler, so we only signal here.
     if let Some(ref sup) = state.supervisor {
         let _ = sup.kill(&ulid, libc::SIGKILL).await;
     }

--- a/backend/src/pty.rs
+++ b/backend/src/pty.rs
@@ -18,6 +18,36 @@ use crate::ringbuf::{RingBuf, DEFAULT_CAPACITY};
 use crate::sandbox::{SandboxState, SandboxStatus};
 use crate::session::{Session, SessionId, SessionState};
 
+/// Reap a PTY child process to prevent it lingering as a zombie.
+///
+/// `std::process::Child` (what portable_pty returns on Unix) does NOT call
+/// `waitpid` on drop, so hangard's `DELETE /sessions/:id` path used to leave
+/// `Zs` entries parented to hangard until hangard itself exited. See #51.
+///
+/// Strategy: poll `try_wait` during a grace window so cleanly-exiting
+/// children (driver.shutdown already sent ctrl-d / `/exit`) are reaped
+/// without an extra signal; if still alive at the deadline, `kill()` (which
+/// portable_pty escalates SIGHUP → SIGKILL internally) and then block on
+/// `wait()`.
+pub fn reap_child(child_arc: Arc<Mutex<Box<dyn Child + Send>>>, grace: Duration) {
+    let mut child = match child_arc.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let deadline = std::time::Instant::now() + grace;
+    while std::time::Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(_) => break,
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
 pub enum PtyMaster {
     Local(Arc<Mutex<Box<dyn MasterPty + Send>>>),
     Attached(Arc<Mutex<RawFdMaster>>),

--- a/backend/tests/delete_reap_test.rs
+++ b/backend/tests/delete_reap_test.rs
@@ -1,0 +1,194 @@
+// Regression test for #51: DELETE /sessions/:id must reap the PTY child so
+// no zombie (state `Z`) remains parented to this (the test hangard) process.
+//
+// Uses the shell driver so no external binary (claude) is required. The test
+// spawns a real PTY via the in-process axum server, sends a long-running
+// prompt (`yes | head -n ...`) so the child is actively writing at DELETE
+// time, then asserts the PID disappears from /proc within a short grace
+// window and is not left in `Z` state.
+//
+// Marked `#[ignore]` like the other PTY tests because it allocates a real
+// terminal — run with: `cargo test -p hangard delete_reap -- --ignored`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+use hangard::{api, db::Db, events::EventBus, AppState};
+
+async fn spawn_test_server() -> (String, tokio::task::JoinHandle<()>) {
+    let db = Db::new_in_memory().await.unwrap();
+    let event_bus = Arc::new(EventBus::new());
+    let tmp = tempfile::tempdir().unwrap();
+    let ring_dir = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+
+    let logs_config = hangard::config::LogsConfig::default();
+    let mut logs_hub = hangard::logs::LogsHub::new(&logs_config, &ring_dir);
+    logs_hub.start();
+
+    let state = AppState {
+        db,
+        event_bus,
+        ring_dir,
+        hook_channels: Arc::new(Mutex::new(HashMap::new())),
+        sessions: Arc::new(RwLock::new(HashMap::new())),
+        supervisor: None,
+        start_time: Instant::now(),
+        sandbox_manager: None,
+        logs: Arc::new(logs_hub),
+    };
+
+    let router = api::router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    (base_url, handle)
+}
+
+/// Read /proc/self/task/*/children (or /proc/<ppid>/task/*/children on Linux
+/// with CONFIG_PROC_CHILDREN) to find any child PIDs of the current process.
+/// Falls back to walking /proc looking for matching PPIDs.
+fn child_pids_of_self() -> Vec<i32> {
+    let my_pid = std::process::id() as i32;
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir("/proc") {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Ok(pid) = name.parse::<i32>() else {
+            continue;
+        };
+        let stat_path = format!("/proc/{pid}/stat");
+        let stat = match std::fs::read_to_string(&stat_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        // /proc/<pid>/stat format: "<pid> (<comm>) <state> <ppid> ..."
+        // comm can contain spaces/parens; parse from the last ')'.
+        let Some(close) = stat.rfind(')') else {
+            continue;
+        };
+        let tail = &stat[close + 1..];
+        let mut toks = tail.split_whitespace();
+        let _state = toks.next();
+        let Some(ppid_str) = toks.next() else {
+            continue;
+        };
+        let Ok(ppid) = ppid_str.parse::<i32>() else {
+            continue;
+        };
+        if ppid == my_pid {
+            out.push(pid);
+        }
+    }
+    out
+}
+
+fn proc_state(pid: i32) -> Option<char> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let close = stat.rfind(')')?;
+    let tail = &stat[close + 1..];
+    tail.split_whitespace().next()?.chars().next()
+}
+
+#[tokio::test]
+#[ignore = "requires PTY allocation; run manually with: cargo test -- --ignored"]
+async fn delete_mid_stream_leaves_no_zombies() {
+    let (base, _server) = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Baseline — record any pre-existing children so we can ignore them.
+    let baseline: std::collections::HashSet<i32> = child_pids_of_self().into_iter().collect();
+
+    // Create a shell session.
+    let resp = client
+        .post(format!("{base}/api/v1/sessions"))
+        .json(&serde_json::json!({
+            "slug": "reap-test",
+            "kind": {"type": "shell"},
+            "cols": 80,
+            "rows": 24
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let session: serde_json::Value = resp.json().await.unwrap();
+    let id = session["id"].as_str().unwrap().to_string();
+
+    // Let the PTY come up so `ps`/`/proc` will list the child.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let new_children: Vec<i32> = child_pids_of_self()
+        .into_iter()
+        .filter(|p| !baseline.contains(p))
+        .collect();
+    assert!(
+        !new_children.is_empty(),
+        "expected at least one PTY child after spawn"
+    );
+
+    // Kick off a long-running stream so DELETE fires mid-output.
+    let resp = client
+        .post(format!("{base}/api/v1/sessions/{id}/prompt"))
+        .json(&serde_json::json!({"text": "yes hangar | head -n 100000"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+
+    // Small beat, then DELETE mid-stream.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let resp = client
+        .delete(format!("{base}/api/v1/sessions/{id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+
+    // Grace window for the reaper task. reap_child uses ~500ms; give it
+    // comfortably more so a slow shell-exit doesn't flake the test.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let still: Vec<(i32, Option<char>)> = new_children
+            .iter()
+            .filter_map(|p| {
+                let st = proc_state(*p);
+                // Gone from /proc entirely → fully reaped.
+                if st.is_none() {
+                    None
+                } else {
+                    Some((*p, st))
+                }
+            })
+            .collect();
+
+        if still.is_empty() {
+            return;
+        }
+
+        // Any surviving entry must not be a zombie.
+        let zombies: Vec<_> = still.iter().filter(|(_, s)| *s == Some('Z')).collect();
+        if zombies.is_empty() && Instant::now() > deadline {
+            panic!(
+                "children still alive after grace (not zombies, but not reaped either): {:?}",
+                still
+            );
+        }
+        if !zombies.is_empty() && Instant::now() > deadline {
+            panic!("zombie processes parented to test hangard after DELETE: {zombies:?}");
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #51. `DELETE /sessions/:id` used to return 204 and kill the PTY, but leaves `Zs` (defunct) entries parented to hangard because `std::process::Child` on Unix does not call `waitpid` on drop. Under a long-running daemon, each mid-stream DELETE leaked a pair of zombies until hangard exited.

## Cause

`backend/src/api/sessions.rs::delete_session` calls `driver.shutdown()` (which writes ctrl-D / `/exit` through the master), drops the `ActiveSession`, and returns. The underlying `Box<dyn Child>` is never explicitly reaped. Supervisor-held children were fine — the supervisor daemon has a SIGCHLD handler — but direct (non-supervised) PTY spawns were not.

## Fix

- New `pty::reap_child(child_arc, grace)` that polls `try_wait` during a short grace window, then escalates `kill() + wait()` if the process is still alive. `portable_pty::Child::kill` internally walks SIGHUP → SIGKILL, so this is terminal.
- `delete_session` dispatches the reap via `tokio::task::spawn_blocking` immediately after `driver.shutdown()`, so the 204 response is not blocked on the grace window but the zombie is still reaped deterministically.
- Supervisor path is unchanged — its own `SIGCHLD` handler already reaps, the existing `sup.kill(SIGKILL)` call stays.

## Test plan

- [x] `cargo test -p hangard` — all pre-existing tests green
- [x] New `backend/tests/delete_reap_test.rs::delete_mid_stream_leaves_no_zombies` — spawns a shell session, kicks off a long `yes | head -n 100000` stream, DELETEs mid-stream, asserts no `Z`-state PIDs remain parented to the test hangard within a 3s grace. Verified it **fails** on the pre-fix tree (`zombie processes parented to test hangard after DELETE: [(382370, Some('Z'))]`) and **passes** with the fix applied.
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean

## Refs

Closes #51. Follows up on #49 (DELETE handler that exposed this).