### PR TITLE
feat: in-session code + diff viewer (closes #48)

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod prompt;
 pub mod resize;
 pub mod search;
 pub mod sessions;
+pub mod worktree;
 
 use axum::{
     extract::State,
@@ -58,6 +59,18 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/sessions/:id/prompt", post(prompt::prompt_session))
         .route("/api/v1/sessions/:id/key", post(key::send_key))
         .route("/api/v1/sessions/:id/fsdiff", get(sessions::get_fs_diff))
+        .route(
+            "/api/v1/sessions/:id/worktree/tree",
+            get(worktree::get_tree),
+        )
+        .route(
+            "/api/v1/sessions/:id/worktree/file",
+            get(worktree::get_file),
+        )
+        .route(
+            "/api/v1/sessions/:id/worktree/diff",
+            get(worktree::get_diff),
+        )
         .route(
             "/api/v1/sessions/:id/merge-overlay",
             post(sessions::merge_overlay_handler),

--- a/backend/src/api/worktree.rs
+++ b/backend/src/api/worktree.rs
@@ -1,0 +1,400 @@
+//! In-session worktree viewer endpoints (issue #48 v0).
+//!
+//! Read-only endpoints that expose the git state of a session's cwd so
+//! the UI can render a VS-Code-style file tree + diff pane.
+//!
+//! * `GET /api/v1/sessions/:id/worktree/tree` — tracked + modified files
+//!   with per-file status.
+//! * `GET /api/v1/sessions/:id/worktree/file?path=<rel>` — file contents
+//!   (trimmed to 500 KB).
+//! * `GET /api/v1/sessions/:id/worktree/diff?path=<rel>` — unified diff
+//!   vs HEAD for one file.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use axum::{
+    extract::{Path as AxumPath, Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::api::resolve_session;
+use crate::AppState;
+
+const MAX_FILE_BYTES: usize = 500 * 1024;
+const MAX_DIFF_BYTES: usize = 1024 * 1024;
+
+#[derive(Serialize)]
+pub struct TreeEntry {
+    pub path: String,
+    pub status: FileStatus,
+}
+
+#[derive(Serialize)]
+pub struct TreeResponse {
+    pub root: String,
+    pub branch: Option<String>,
+    pub entries: Vec<TreeEntry>,
+}
+
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum FileStatus {
+    Clean,
+    Modified,
+    Added,
+    Deleted,
+    Untracked,
+    Renamed,
+}
+
+#[derive(Deserialize)]
+pub struct PathParams {
+    pub path: String,
+}
+
+#[derive(Serialize)]
+pub struct FileResponse {
+    pub path: String,
+    pub size: u64,
+    pub truncated: bool,
+    pub binary: bool,
+    pub content: String,
+}
+
+#[derive(Serialize)]
+pub struct DiffResponse {
+    pub path: String,
+    pub diff: String,
+    pub truncated: bool,
+}
+
+/// Look up the session, return its cwd as a git worktree root or 404.
+async fn session_worktree(state: &AppState, id: &str) -> Result<PathBuf, (StatusCode, String)> {
+    let session = resolve_session(state, id)
+        .await
+        .map_err(|s| (s, "session not found".to_string()))?;
+    let cwd = PathBuf::from(&session.cwd);
+    if !cwd.exists() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("session cwd {} does not exist", cwd.display()),
+        ));
+    }
+    // Confirm it's inside a git worktree.
+    let out = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(&cwd)
+        .output();
+    let top = match out {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                "session cwd is not inside a git worktree".to_string(),
+            ))
+        }
+    };
+    Ok(PathBuf::from(top))
+}
+
+/// Resolve a user-supplied relative path against `root` and refuse any
+/// path that escapes the worktree via `..` or symlinks.
+fn safe_resolve(root: &Path, rel: &str) -> Result<PathBuf, (StatusCode, String)> {
+    if rel.is_empty() || rel.starts_with('/') {
+        return Err((StatusCode::BAD_REQUEST, "path must be relative".into()));
+    }
+    let joined = root.join(rel);
+    // Canonicalize the parent; the file itself may not exist (deleted).
+    let canonical_parent = match joined.parent() {
+        Some(p) => std::fs::canonicalize(p)
+            .map_err(|e| (StatusCode::NOT_FOUND, format!("bad path: {e}")))?,
+        None => return Err((StatusCode::BAD_REQUEST, "bad path".into())),
+    };
+    let canonical_root = std::fs::canonicalize(root).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("canonicalize root: {e}"),
+        )
+    })?;
+    if !canonical_parent.starts_with(&canonical_root) {
+        return Err((StatusCode::FORBIDDEN, "path escapes worktree".into()));
+    }
+    Ok(canonical_parent.join(joined.file_name().unwrap_or_default()))
+}
+
+fn current_branch(root: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Parse `git status --porcelain=v1 -z` → map of path → status.
+///
+/// v1 is simpler to parse than v2 and gives us enough info for v0.
+/// Format: `XY<space><path>\0` (renames add `<orig>\0` after).
+fn status_map(root: &Path) -> Result<BTreeMap<String, FileStatus>, String> {
+    let out = Command::new("git")
+        .args(["status", "--porcelain=v1", "-z"])
+        .current_dir(root)
+        .output()
+        .map_err(|e| format!("git status: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "git status failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    let mut map = BTreeMap::new();
+    let mut iter = out.stdout.split(|b| *b == 0).peekable();
+    while let Some(entry) = iter.next() {
+        if entry.is_empty() {
+            continue;
+        }
+        if entry.len() < 4 {
+            continue;
+        }
+        let x = entry[0] as char;
+        let y = entry[1] as char;
+        // byte 2 is space
+        let path = String::from_utf8_lossy(&entry[3..]).to_string();
+        // For renames (R) the next chunk is the old path — consume it.
+        if x == 'R' || y == 'R' {
+            iter.next();
+        }
+        let status = match (x, y) {
+            ('?', _) => FileStatus::Untracked,
+            ('A', _) | (_, 'A') => FileStatus::Added,
+            ('D', _) | (_, 'D') => FileStatus::Deleted,
+            ('R', _) | (_, 'R') => FileStatus::Renamed,
+            ('M', _) | (_, 'M') => FileStatus::Modified,
+            _ => FileStatus::Modified,
+        };
+        map.insert(path, status);
+    }
+    Ok(map)
+}
+
+/// List tracked + untracked-non-ignored files via `git ls-files`.
+fn tracked_files(root: &Path) -> Result<Vec<String>, String> {
+    let out = Command::new("git")
+        .args([
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+        ])
+        .current_dir(root)
+        .output()
+        .map_err(|e| format!("git ls-files: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "git ls-files failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    let files: Vec<String> = out
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| String::from_utf8_lossy(s).to_string())
+        .collect();
+    Ok(files)
+}
+
+pub async fn get_tree(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<TreeResponse>, (StatusCode, String)> {
+    let root = session_worktree(&state, &id).await?;
+    let branch = current_branch(&root);
+    let statuses = status_map(&root).map_err(err500)?;
+    let mut files = tracked_files(&root).map_err(err500)?;
+
+    // Include deleted files (present in status but not in ls-files).
+    for p in statuses.keys() {
+        if !files.iter().any(|f| f == p) {
+            files.push(p.clone());
+        }
+    }
+    files.sort();
+    files.dedup();
+
+    let entries = files
+        .into_iter()
+        .map(|p| {
+            let status = statuses.get(&p).copied().unwrap_or(FileStatus::Clean);
+            TreeEntry { path: p, status }
+        })
+        .collect();
+
+    Ok(Json(TreeResponse {
+        root: root.display().to_string(),
+        branch,
+        entries,
+    }))
+}
+
+pub async fn get_file(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Query(params): Query<PathParams>,
+) -> Result<Json<FileResponse>, (StatusCode, String)> {
+    let root = session_worktree(&state, &id).await?;
+    let abs = safe_resolve(&root, &params.path)?;
+    let bytes = std::fs::read(&abs)
+        .map_err(|e| (StatusCode::NOT_FOUND, format!("read {}: {e}", params.path)))?;
+    let total_len = bytes.len() as u64;
+    let binary = bytes.iter().take(8192).any(|b| *b == 0);
+    let (content, truncated) = if binary {
+        (String::new(), false)
+    } else if bytes.len() > MAX_FILE_BYTES {
+        (
+            String::from_utf8_lossy(&bytes[..MAX_FILE_BYTES]).to_string(),
+            true,
+        )
+    } else {
+        (String::from_utf8_lossy(&bytes).to_string(), false)
+    };
+
+    Ok(Json(FileResponse {
+        path: params.path,
+        size: total_len,
+        truncated,
+        binary,
+        content,
+    }))
+}
+
+pub async fn get_diff(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Query(params): Query<PathParams>,
+) -> Result<Json<DiffResponse>, (StatusCode, String)> {
+    let root = session_worktree(&state, &id).await?;
+    // Validate the relative path (existence not required; file may be
+    // deleted). We only care that it doesn't escape the worktree.
+    if params.path.contains("..") || params.path.starts_with('/') {
+        return Err((StatusCode::BAD_REQUEST, "bad path".into()));
+    }
+
+    // `git diff HEAD --` covers both staged and unstaged changes, and
+    // includes untracked? No — untracked files aren't tracked. For
+    // untracked, fall back to `git diff --no-index /dev/null <path>`.
+    let out = Command::new("git")
+        .args(["diff", "HEAD", "--", &params.path])
+        .current_dir(&root)
+        .output()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("git diff: {e}")))?;
+
+    let mut diff = String::from_utf8_lossy(&out.stdout).to_string();
+
+    if diff.is_empty() {
+        // Untracked file → synthesize an add-style diff.
+        let abs = root.join(&params.path);
+        if abs.exists() {
+            let no_index = Command::new("git")
+                .args(["diff", "--no-index", "--", "/dev/null", &params.path])
+                .current_dir(&root)
+                .output();
+            if let Ok(o) = no_index {
+                // no-index returns exit code 1 on difference; that's fine.
+                diff = String::from_utf8_lossy(&o.stdout).to_string();
+            }
+        }
+    }
+
+    let truncated = diff.len() > MAX_DIFF_BYTES;
+    if truncated {
+        diff.truncate(MAX_DIFF_BYTES);
+    }
+
+    Ok(Json(DiffResponse {
+        path: params.path,
+        diff,
+        truncated,
+    }))
+}
+
+fn err500<E: std::fmt::Display>(e: E) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn run(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn init_repo() -> TempDir {
+        let td = TempDir::new().unwrap();
+        run(td.path(), &["init", "-q", "-b", "main"]);
+        run(td.path(), &["config", "user.email", "t@t"]);
+        run(td.path(), &["config", "user.name", "t"]);
+        fs::write(td.path().join("a.txt"), "hello\n").unwrap();
+        run(td.path(), &["add", "."]);
+        run(td.path(), &["commit", "-qm", "init"]);
+        td
+    }
+
+    #[test]
+    fn status_map_reports_modified_and_untracked() {
+        let td = init_repo();
+        fs::write(td.path().join("a.txt"), "changed\n").unwrap();
+        fs::write(td.path().join("new.txt"), "fresh\n").unwrap();
+        let m = status_map(td.path()).unwrap();
+        assert_eq!(m.get("a.txt").copied(), Some(FileStatus::Modified));
+        assert_eq!(m.get("new.txt").copied(), Some(FileStatus::Untracked));
+    }
+
+    #[test]
+    fn tracked_files_includes_untracked_non_ignored() {
+        let td = init_repo();
+        fs::write(td.path().join("b.txt"), "b\n").unwrap();
+        let files = tracked_files(td.path()).unwrap();
+        assert!(files.contains(&"a.txt".to_string()));
+        assert!(files.contains(&"b.txt".to_string()));
+    }
+
+    #[test]
+    fn safe_resolve_rejects_escape() {
+        let td = init_repo();
+        let root = td.path();
+        // Parent (".." of the worktree root) is guaranteed to exist
+        // because TempDir lives under /tmp, so canonicalize succeeds and
+        // the prefix check fires with 403 rather than a 404.
+        let err = safe_resolve(root, "../escape.txt").unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn safe_resolve_rejects_absolute() {
+        let td = init_repo();
+        let err = safe_resolve(td.path(), "/etc/passwd").unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,16 @@
-import type { Session, StoredEvent, CreateSessionRequest, LabelEntry, SessionKind, FsDiffResponse, LogSource, SearchResult } from './types';
+import type {
+	Session,
+	StoredEvent,
+	CreateSessionRequest,
+	LabelEntry,
+	SessionKind,
+	FsDiffResponse,
+	LogSource,
+	SearchResult,
+	WorktreeTreeResponse,
+	WorktreeFileResponse,
+	WorktreeDiffResponse
+} from './types';
 
 export class ApiError extends Error {
 	constructor(
@@ -126,6 +138,29 @@ export async function mergeOverlay(id: string): Promise<Session> {
 	const res = await checkOk(
 		await fetch(`/api/v1/sessions/${id}/merge-overlay`, { method: 'POST' })
 	);
+	return res.json();
+}
+
+export async function getWorktreeTree(id: string): Promise<WorktreeTreeResponse> {
+	const res = await checkOk(await fetch(`/api/v1/sessions/${id}/worktree/tree`));
+	return res.json();
+}
+
+export async function getWorktreeFile(
+	id: string,
+	path: string
+): Promise<WorktreeFileResponse> {
+	const qs = new URLSearchParams({ path }).toString();
+	const res = await checkOk(await fetch(`/api/v1/sessions/${id}/worktree/file?${qs}`));
+	return res.json();
+}
+
+export async function getWorktreeDiff(
+	id: string,
+	path: string
+): Promise<WorktreeDiffResponse> {
+	const qs = new URLSearchParams({ path }).toString();
+	const res = await checkOk(await fetch(`/api/v1/sessions/${id}/worktree/diff?${qs}`));
 	return res.json();
 }
 

--- a/frontend/src/lib/components/CodeViewer.svelte
+++ b/frontend/src/lib/components/CodeViewer.svelte
@@ -1,0 +1,565 @@
+<script lang="ts">
+	import { getWorktreeTree, getWorktreeFile, getWorktreeDiff, ApiError } from '$lib/api';
+	import type {
+		WorktreeTreeResponse,
+		WorktreeEntry,
+		WorktreeFileResponse,
+		WorktreeDiffResponse,
+		WorktreeFileStatus
+	} from '$lib/types';
+
+	let { sessionId }: { sessionId: string } = $props();
+
+	let tree = $state<WorktreeTreeResponse | null>(null);
+	let treeError = $state<string | null>(null);
+	let loadingTree = $state(false);
+
+	let selected = $state<string | null>(null);
+	let mode = $state<'file' | 'diff'>('diff');
+	let file = $state<WorktreeFileResponse | null>(null);
+	let diff = $state<WorktreeDiffResponse | null>(null);
+	let fileError = $state<string | null>(null);
+	let loadingFile = $state(false);
+
+	// Build a folder tree from flat paths.
+	interface TreeNode {
+		name: string;
+		path: string;
+		isDir: boolean;
+		status?: WorktreeFileStatus;
+		children: TreeNode[];
+	}
+
+	let collapsed = $state<Record<string, boolean>>({});
+
+	function buildTree(entries: WorktreeEntry[]): TreeNode {
+		const root: TreeNode = { name: '', path: '', isDir: true, children: [] };
+		for (const e of entries) {
+			const parts = e.path.split('/');
+			let cur = root;
+			for (let i = 0; i < parts.length; i++) {
+				const part = parts[i];
+				const isLast = i === parts.length - 1;
+				let next = cur.children.find((c) => c.name === part);
+				if (!next) {
+					next = {
+						name: part,
+						path: parts.slice(0, i + 1).join('/'),
+						isDir: !isLast,
+						status: isLast ? e.status : undefined,
+						children: []
+					};
+					cur.children.push(next);
+				}
+				cur = next;
+			}
+		}
+		sortNode(root);
+		return root;
+	}
+
+	function sortNode(n: TreeNode) {
+		n.children.sort((a, b) => {
+			if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+			return a.name.localeCompare(b.name);
+		});
+		for (const c of n.children) sortNode(c);
+	}
+
+	// Folders that contain any dirty descendant should show a dot too.
+	function dirtyFolder(n: TreeNode): boolean {
+		if (!n.isDir) return false;
+		return n.children.some(
+			(c) =>
+				(!c.isDir && c.status && c.status !== 'clean') ||
+				(c.isDir && dirtyFolder(c))
+		);
+	}
+
+	let rootNode = $derived(tree ? buildTree(tree.entries) : null);
+	let dirtyCount = $derived(
+		tree ? tree.entries.filter((e) => e.status !== 'clean').length : 0
+	);
+
+	async function loadTree() {
+		loadingTree = true;
+		treeError = null;
+		try {
+			tree = await getWorktreeTree(sessionId);
+		} catch (e) {
+			tree = null;
+			treeError =
+				e instanceof ApiError
+					? e.status === 404
+						? 'This session is not inside a git worktree.'
+						: `${e.status}: ${e.body || e.message}`
+					: e instanceof Error
+						? e.message
+						: 'Failed to load tree';
+		} finally {
+			loadingTree = false;
+		}
+	}
+
+	async function loadPath(path: string) {
+		selected = path;
+		fileError = null;
+		loadingFile = true;
+		file = null;
+		diff = null;
+
+		// Pick default mode: diff if the file is dirty, else file.
+		const entry = tree?.entries.find((e) => e.path === path);
+		mode =
+			entry && entry.status !== 'clean' && entry.status !== 'deleted' ? 'diff' : 'file';
+		if (entry?.status === 'deleted') mode = 'diff';
+
+		try {
+			if (mode === 'file') {
+				file = await getWorktreeFile(sessionId, path);
+			} else {
+				diff = await getWorktreeDiff(sessionId, path);
+			}
+		} catch (e) {
+			fileError =
+				e instanceof ApiError
+					? `${e.status}: ${e.body || e.message}`
+					: e instanceof Error
+						? e.message
+						: 'Failed to load file';
+		} finally {
+			loadingFile = false;
+		}
+	}
+
+	async function switchMode(next: 'file' | 'diff') {
+		if (next === mode || !selected) {
+			mode = next;
+			return;
+		}
+		mode = next;
+		fileError = null;
+		loadingFile = true;
+		try {
+			if (next === 'file') {
+				if (!file) file = await getWorktreeFile(sessionId, selected);
+			} else {
+				if (!diff) diff = await getWorktreeDiff(sessionId, selected);
+			}
+		} catch (e) {
+			fileError =
+				e instanceof ApiError
+					? `${e.status}: ${e.body || e.message}`
+					: e instanceof Error
+						? e.message
+						: 'Failed to load file';
+		} finally {
+			loadingFile = false;
+		}
+	}
+
+	function toggleCollapse(path: string) {
+		collapsed[path] = !collapsed[path];
+	}
+
+	function statusDotClass(s: WorktreeFileStatus | undefined): string {
+		if (!s) return '';
+		if (s === 'clean') return '';
+		return `dot-${s}`;
+	}
+
+	function statusTitle(s: WorktreeFileStatus | undefined): string {
+		switch (s) {
+			case 'added':
+			case 'untracked':
+				return 'added';
+			case 'modified':
+			case 'renamed':
+				return 'modified';
+			case 'deleted':
+				return 'deleted';
+			default:
+				return '';
+		}
+	}
+
+	function diffLineClass(line: string): string {
+		if (line.startsWith('+++') || line.startsWith('---')) return 'diff-meta';
+		if (line.startsWith('@@')) return 'diff-hunk';
+		if (line.startsWith('+')) return 'diff-add';
+		if (line.startsWith('-')) return 'diff-del';
+		if (line.startsWith('diff ') || line.startsWith('index ')) return 'diff-meta';
+		return '';
+	}
+
+	$effect(() => {
+		// Reload when sessionId changes
+		sessionId;
+		loadTree();
+	});
+</script>
+
+<div class="code-viewer">
+	<div class="cv-header">
+		<span class="cv-title">Code</span>
+		{#if tree?.branch}
+			<span class="cv-branch" title="Branch">⎇ {tree.branch}</span>
+		{/if}
+		{#if tree}
+			<span class="cv-count">{dirtyCount} changed / {tree.entries.length} files</span>
+		{/if}
+		<button class="cv-refresh" onclick={loadTree} disabled={loadingTree} title="Refresh">
+			{loadingTree ? '…' : '↻'}
+		</button>
+	</div>
+
+	<div class="cv-body">
+		<aside class="cv-tree">
+			{#if loadingTree && !tree}
+				<div class="cv-loading">Loading…</div>
+			{:else if treeError}
+				<div class="cv-error">{treeError}</div>
+			{:else if rootNode}
+				{@render renderNode(rootNode, 0)}
+			{/if}
+		</aside>
+
+		<section class="cv-pane">
+			{#if !selected}
+				<div class="cv-placeholder">Select a file from the tree.</div>
+			{:else}
+				<div class="cv-pane-header">
+					<span class="cv-pane-path mono">{selected}</span>
+					<div class="cv-mode-toggle">
+						<button
+							class:active={mode === 'file'}
+							onclick={() => switchMode('file')}
+							disabled={loadingFile}
+						>
+							File
+						</button>
+						<button
+							class:active={mode === 'diff'}
+							onclick={() => switchMode('diff')}
+							disabled={loadingFile}
+						>
+							Diff
+						</button>
+					</div>
+				</div>
+				{#if fileError}
+					<div class="cv-error">{fileError}</div>
+				{:else if loadingFile}
+					<div class="cv-loading">Loading…</div>
+				{:else if mode === 'file' && file}
+					{#if file.binary}
+						<div class="cv-placeholder">Binary file ({file.size} bytes) — not rendered.</div>
+					{:else}
+						<pre class="cv-file mono">{file.content}</pre>
+						{#if file.truncated}
+							<div class="cv-notice">File truncated at 500 KB.</div>
+						{/if}
+					{/if}
+				{:else if mode === 'diff' && diff}
+					{#if diff.diff === ''}
+						<div class="cv-placeholder">No diff vs HEAD.</div>
+					{:else}
+						<pre class="cv-diff mono">{#each diff.diff.split('\n') as line, i (i)}<span
+									class={diffLineClass(line)}>{line}
+</span>{/each}</pre>
+						{#if diff.truncated}
+							<div class="cv-notice">Diff truncated at 1 MB.</div>
+						{/if}
+					{/if}
+				{/if}
+			{/if}
+		</section>
+	</div>
+</div>
+
+{#snippet renderNode(node: TreeNode, depth: number)}
+	{#if depth > 0}
+		{@const isOpen = !collapsed[node.path]}
+		<div
+			class="cv-row"
+			class:cv-dir={node.isDir}
+			style:padding-left="{depth * 12}px"
+			role="button"
+			tabindex="0"
+			onclick={() => (node.isDir ? toggleCollapse(node.path) : loadPath(node.path))}
+			onkeydown={(e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					node.isDir ? toggleCollapse(node.path) : loadPath(node.path);
+				}
+			}}
+			aria-pressed={!node.isDir && selected === node.path ? 'true' : undefined}
+		>
+			{#if node.isDir}
+				<span class="cv-caret">{isOpen ? '▾' : '▸'}</span>
+				<span class="cv-name">{node.name}</span>
+				{#if dirtyFolder(node)}
+					<span class="cv-dot dot-modified" title="contains changes"></span>
+				{/if}
+			{:else}
+				<span class="cv-caret-spacer"></span>
+				<span
+					class="cv-name cv-file-name"
+					class:cv-selected={selected === node.path}
+				>
+					{node.name}
+				</span>
+				{#if node.status && node.status !== 'clean'}
+					<span
+						class="cv-dot {statusDotClass(node.status)}"
+						title={statusTitle(node.status)}
+					></span>
+				{/if}
+			{/if}
+		</div>
+	{/if}
+	{#if node.isDir && (depth === 0 || !collapsed[node.path])}
+		{#each node.children as child (child.path)}
+			{@render renderNode(child, depth + 1)}
+		{/each}
+	{/if}
+{/snippet}
+
+<style>
+	.code-viewer {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+		background: var(--bg-surface, var(--bg));
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		overflow: hidden;
+		font-size: 0.8rem;
+	}
+
+	.cv-header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 6px 10px;
+		border-bottom: 1px solid var(--border);
+		background: var(--bg);
+		flex-shrink: 0;
+	}
+
+	.cv-title {
+		font-weight: 600;
+		color: var(--text);
+	}
+
+	.cv-branch {
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	.cv-count {
+		font-size: 0.72rem;
+		color: var(--text-muted);
+		margin-left: auto;
+	}
+
+	.cv-refresh {
+		background: transparent;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 0.8rem;
+		padding: 2px 8px;
+	}
+
+	.cv-refresh:disabled {
+		opacity: 0.5;
+	}
+
+	.cv-refresh:hover:not(:disabled) {
+		color: var(--text);
+	}
+
+	.cv-body {
+		display: grid;
+		grid-template-columns: 240px 1fr;
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.cv-tree {
+		overflow-y: auto;
+		border-right: 1px solid var(--border);
+		padding: 4px 0;
+		background: var(--bg);
+	}
+
+	.cv-pane {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.cv-pane-header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 6px 10px;
+		border-bottom: 1px solid var(--border);
+		background: var(--bg);
+		flex-shrink: 0;
+	}
+
+	.cv-pane-path {
+		font-size: 0.75rem;
+		color: var(--text);
+		flex: 1;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.cv-mode-toggle {
+		display: flex;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		overflow: hidden;
+	}
+
+	.cv-mode-toggle button {
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 0.72rem;
+		padding: 3px 8px;
+	}
+
+	.cv-mode-toggle button.active {
+		background: var(--accent, #7c3aed);
+		color: #fff;
+	}
+
+	.cv-mode-toggle button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.cv-row {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 8px 2px 0;
+		cursor: pointer;
+		user-select: none;
+		color: var(--text);
+		white-space: nowrap;
+	}
+
+	.cv-row:hover {
+		background: rgba(255, 255, 255, 0.05);
+	}
+
+	.cv-caret {
+		width: 10px;
+		color: var(--text-muted);
+		font-size: 0.7rem;
+	}
+
+	.cv-caret-spacer {
+		width: 10px;
+	}
+
+	.cv-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		flex: 1;
+	}
+
+	.cv-file-name.cv-selected {
+		color: var(--accent, #7c3aed);
+		font-weight: 600;
+	}
+
+	.cv-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.cv-dot.dot-modified,
+	.cv-dot.dot-renamed {
+		background: #ff9800;
+	}
+
+	.cv-dot.dot-added,
+	.cv-dot.dot-untracked {
+		background: #4caf50;
+	}
+
+	.cv-dot.dot-deleted {
+		background: #f44336;
+	}
+
+	.cv-file,
+	.cv-diff {
+		margin: 0;
+		padding: 8px 10px;
+		flex: 1;
+		overflow: auto;
+		font-size: 0.78rem;
+		line-height: 1.45;
+		background: var(--bg);
+		color: var(--text);
+		white-space: pre;
+	}
+
+	.cv-diff :global(.diff-add) {
+		color: #4caf50;
+	}
+
+	.cv-diff :global(.diff-del) {
+		color: #f44336;
+	}
+
+	.cv-diff :global(.diff-hunk) {
+		color: #7aa2f7;
+	}
+
+	.cv-diff :global(.diff-meta) {
+		color: var(--text-muted);
+	}
+
+	.cv-placeholder,
+	.cv-loading {
+		padding: 14px;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+
+	.cv-error {
+		padding: 14px;
+		color: #f44336;
+		font-size: 0.8rem;
+	}
+
+	.cv-notice {
+		padding: 6px 10px;
+		border-top: 1px solid var(--border);
+		color: var(--text-muted);
+		font-size: 0.72rem;
+		flex-shrink: 0;
+	}
+
+	.mono {
+		font-family: var(--font-mono);
+	}
+</style>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -122,6 +122,39 @@ export interface FsDiffEntry {
 	kind: 'added' | 'modified' | 'deleted';
 }
 
+export type WorktreeFileStatus =
+	| 'clean'
+	| 'modified'
+	| 'added'
+	| 'deleted'
+	| 'untracked'
+	| 'renamed';
+
+export interface WorktreeEntry {
+	path: string;
+	status: WorktreeFileStatus;
+}
+
+export interface WorktreeTreeResponse {
+	root: string;
+	branch: string | null;
+	entries: WorktreeEntry[];
+}
+
+export interface WorktreeFileResponse {
+	path: string;
+	size: number;
+	truncated: boolean;
+	binary: boolean;
+	content: string;
+}
+
+export interface WorktreeDiffResponse {
+	path: string;
+	diff: string;
+	truncated: boolean;
+}
+
 export interface FsDiffResponse {
 	entries: FsDiffEntry[];
 	total: number;

--- a/frontend/src/routes/session/[id]/+page.svelte
+++ b/frontend/src/routes/session/[id]/+page.svelte
@@ -9,6 +9,7 @@
 	import InsightsPanel from '$lib/components/InsightsPanel.svelte';
 	import TerminalView from '$lib/components/TerminalView.svelte';
 	import SandboxDiffView from '$lib/components/SandboxDiffView.svelte';
+	import CodeViewer from '$lib/components/CodeViewer.svelte';
 
 	let { data }: { data: { session: Session } } = $props();
 
@@ -18,6 +19,7 @@
 	let confirmOpen = $state(false);
 	let killing = $state(false);
 	let killError = $state<string | null>(null);
+	let codeOpen = $state(false);
 
 	$effect(() => {
 		const id = data.session.id;
@@ -84,6 +86,15 @@
 		{#if session.agent_meta?.model}
 			<span class="model-name mono">{session.agent_meta.model}</span>
 		{/if}
+		<button
+			class="code-btn"
+			class:active={codeOpen}
+			type="button"
+			title="Toggle code viewer"
+			onclick={() => (codeOpen = !codeOpen)}
+		>
+			{codeOpen ? '▾' : '▸'} Code
+		</button>
 		<button
 			class="kill-btn"
 			type="button"
@@ -153,8 +164,15 @@
 
 	<div class="session-body">
 		{#key session.id}
-			<div class="split" class:insights-collapsed={insightsCollapsed}>
+			<div
+				class="split"
+				class:insights-collapsed={insightsCollapsed}
+				class:split-with-code={codeOpen}
+			>
 				<div class="main-pane"><TerminalView {session} /></div>
+				{#if codeOpen}
+					<div class="code-pane"><CodeViewer sessionId={session.id} /></div>
+				{/if}
 				<aside class="side-pane">
 					<div class="side-header">
 						<button
@@ -283,6 +301,20 @@
 		grid-template-columns: 1fr 36px;
 	}
 
+	.split-with-code {
+		grid-template-columns: 1fr minmax(320px, 40%) 280px;
+	}
+
+	.split-with-code.insights-collapsed {
+		grid-template-columns: 1fr minmax(320px, 40%) 36px;
+	}
+
+	.code-pane {
+		overflow: hidden;
+		min-width: 0;
+		background: var(--bg);
+	}
+
 	.main-pane {
 		overflow: hidden;
 		display: flex;
@@ -362,6 +394,22 @@
 	.sandbox-error {
 		font-size: 0.8rem;
 		color: #f44336;
+	}
+
+	.code-btn {
+		background: transparent;
+		color: var(--text-muted);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: 3px 10px;
+		font-size: 0.8rem;
+		cursor: pointer;
+	}
+
+	.code-btn:hover,
+	.code-btn.active {
+		color: var(--text);
+		background: rgba(255, 255, 255, 0.05);
 	}
 
 	.kill-btn {


### PR DESCRIPTION
## Summary
v0 of the in-session code viewer (issue #48). A collapsible side pane on the session page renders a VS-Code-style file tree + file/diff view for the git worktree the session is running in.

### Backend
- `GET /api/v1/sessions/:id/worktree/tree` — tracked + modified files + branch name, with per-file status (`clean` / `modified` / `added` / `deleted` / `untracked` / `renamed`).
- `GET /api/v1/sessions/:id/worktree/file?path=<rel>` — file contents, capped at 500 KB, with binary detection.
- `GET /api/v1/sessions/:id/worktree/diff?path=<rel>` — unified diff vs `HEAD` for one file; untracked files synthesised via `git diff --no-index`.
- Sessions whose `cwd` isn't inside a git worktree return `404` with a human-readable body.
- Path canonicalisation rejects anything escaping the worktree root.

### Frontend
- New `CodeViewer.svelte` — tree with collapsible folders, coloured status dots (green = added/untracked, amber = modified, red = deleted), and a right pane that toggles between "File" (monospace) and "Diff" (coloured unified diff) modes.
- Session header gets a "Code" toggle button that shows/hides the pane. Kill button and existing layout preserved.
- Zero new frontend dependencies.

## Deferred / follow-up
- Live refresh via filesystem watcher (`notify` already a backend dep) + `FsChanged` WS event.
- Editing / saving files from the browser.
- Syntax highlighting (`shiki` or `highlight.js`) — v0 uses plain monospace.
- Directory listing via `?path=<dir>` for lazy-loaded subtrees (currently flat list is built client-side).
- Richer diff UX (per-hunk accept/reject, inline split-view).
- Binary preview, image rendering.
- Swap data source to the sandbox overlay when a sandboxed session is active.

## Test plan
- [ ] `cargo test --manifest-path backend/Cargo.toml` — new `api::worktree::tests` cover `status_map`, `tracked_files`, and path-traversal rejection.
- [ ] `cargo clippy -- -D warnings` clean.
- [ ] `cargo fmt -- --check` clean.
- [ ] `cd frontend && npm run check && npm run build` clean.
- [ ] Manual: open a shell session rooted in a git worktree → `Code` toggle shows the tree, modified files carry dots, selecting a dirty file defaults to the diff view, toggling to "File" renders contents.
- [ ] Manual: open a session whose cwd isn't a git repo → tree pane shows the 404 message gracefully.
- [ ] Manual: `Ctrl+\` sidebar toggle (from #50 once merged) and kill button still work with the Code pane open.

## Screenshots
_To be added by user._