### PR TITLE
fix(ui): wire "Create one" button via hangar:open-spawn listener

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -9,12 +9,21 @@
 
 	let { children } = $props();
 
+	// hook test edit
 	let spawnOpen = $state(false);
 	let collapsed = $derived(sidebarStore.dashboardCollapsed);
 
 	$effect(() => {
 		sessionsStore.startPolling();
 		return () => sessionsStore.stopPolling();
+	});
+
+	$effect(() => {
+		function onSpawn() {
+			spawnOpen = true;
+		}
+		window.addEventListener('hangar:open-spawn', onSpawn);
+		return () => window.removeEventListener('hangar:open-spawn', onSpawn);
 	});
 
 	$effect(() => {


### PR DESCRIPTION
## Summary
- Adds `window.addEventListener("hangar:open-spawn", …)` in `+layout.svelte` to flip `spawnOpen = true`.
- Cleanup tied to existing `$effect` so listener removes on unmount.

## Why
The empty-state "Create one" button in `+page.svelte` dispatched `hangar:open-spawn` but layout had no listener — clicks did nothing. Topbar `+ New Session` worked because it directly sets the layout-local `spawnOpen`. See #65.

## Test plan
- [x] Verified pre-fix: empty-state click did nothing
- [x] Verified post-fix in dev (HMR): clicking "Create one" opens the modal
- [ ] CI green
- [ ] Optional follow-up: delete the dead `spawnOpen` state in `+page.svelte` for clarity

Closes #65