### PR TITLE
chore(pipeline): mandate UI testing via injected hangar test context

### DIFF
--- a/.pipeline/hangar-test-context.md
+++ b/.pipeline/hangar-test-context.md
@@ -1,0 +1,90 @@
+# Hangar Test Context (read this before testing any hangar change)
+
+You are testing a change in the **hangar** repo — a Rust+SvelteKit agent control plane that runs on this same box. The dashboard is **already live** and the box is dogfooding itself. Test against the live stack — do not start your own copy.
+
+## Live services (already running, do NOT start your own)
+
+- **Dashboard:** http://localhost:5173 (vite dev, tmux `hangar-frontend`)
+- **Backend API:** http://localhost:3000/api/v1 (tmux `hangar-backend`)
+- **Supervisor:** systemd user unit `hangar-supervisor.service`, socket at `~/.local/state/hangar/supervisor.sock`
+- **DB:** `~/.local/state/hangar/hangar.db`
+
+## Pre-flight (run these first, every test session)
+
+```bash
+curl -s localhost:3000/api/v1/health   # expect supervisor_connected: true
+tmux ls | grep hangar                  # expect hangar-backend + hangar-frontend
+systemctl --user is-active hangar-supervisor   # expect active
+```
+
+If any of those fail, halt and report — do not start services yourself, the operator will recover.
+
+## UI testing is MANDATORY for any user-visible change
+
+If your change touches **any** of:
+- `frontend/**`
+- `backend/src/api/**`
+- `backend/src/drivers/**`
+- `backend/src/ws/**`
+- A backend behavior the dashboard observes (events, output, status, sessions, search)
+
+…then **you MUST drive the dashboard via `agent-browser` and take at least one screenshot per scenario**. API-only testing is insufficient and will be rejected.
+
+For pure backend changes with no UI surface (e.g. log format, internal helper), API testing alone is acceptable, but you must still run the **regression smoke** below to confirm nothing broke in the dashboard.
+
+## agent-browser quick reference
+
+```bash
+export PATH=$HOME/.npm-global/bin:$PATH
+agent-browser open "http://localhost:5173" --args "--no-sandbox --headless"
+agent-browser snapshot                   # accessibility tree (preferred for assertions)
+agent-browser screenshot --output /tmp/test-shot-N.png
+agent-browser click "button:has-text(\"+ New Session\")"
+agent-browser fill "input#slug" "my-test-session"
+agent-browser click "button:has-text(\"Create Session\")"
+agent-browser close
+```
+
+Always `close` at the end of each scenario.
+
+## Regression smoke (run on every test, even pure backend changes)
+
+| # | Scenario | Pass criteria |
+|---|---|---|
+| 1 | `agent-browser open localhost:5173` then `snapshot` | Topbar shows "+ New Session" button; no JS errors |
+| 2 | Click "+ New Session", fill slug `smoke-shell-<rand>`, kind=shell, submit | Modal closes, navigates to session page, terminal pane renders, prompt is colored, `[$HOME]` is `[/home/george]` |
+| 3 | Type `ls` + Enter in terminal | Output appears with color codes (verify via screenshot or content snapshot) |
+| 4 | Press `Ctrl+\` twice | Sidebar collapses then re-expands |
+| 5 | Click red "× Kill" button on the session header | Confirms or removes; session disappears from dashboard list within 2s |
+
+If any smoke step fails AND your change did not intend to alter that surface → mark PASS but flag in `notes`. If your change intended to alter it and it now broke → FAIL.
+
+## Cleanup (mandatory before reporting)
+
+```bash
+# DELETE every session your test created
+curl -s localhost:3000/api/v1/sessions \
+  | python3 -c "import sys,json;[print(s['slug']) for s in json.load(sys.stdin) if s['slug'].startswith('smoke-') or s['slug'].startswith('test-')]" \
+  | while read SLUG; do
+      curl -s -o /dev/null -w "DELETE %{http_code} $SLUG\n" -X DELETE "localhost:3000/api/v1/sessions/$SLUG"
+    done
+```
+
+Do NOT delete sessions you did not create.
+
+## Known live bugs — DO NOT refile, only mention if your change affects them
+
+- **#57** SQLite DB malformed (code 267) — DELETE returns 500 on certain pre-existing rows. Surgical sqlite works; integrity_check passes. Suspect FTS5 segments.
+- **#58** FTS query 500 on hyphen/colon (`?q=foo-bar` → `no such column: bar`). Plain words OK.
+- **#59** Parallel DELETE same session returns 2×204 instead of 204+404.
+- **#60** Cost/ctx sidebar lags real CTX line and mislabels "30k" as "output tokens" instead of context.
+- **#62** `create_session` has no `cwd` field — caller-specified working dir is ignored (uses hangard cwd).
+- **#63** Trailing `event persist failed (code 787) FOREIGN KEY constraint failed` log noise after fast DELETE.
+
+If your change is the fix for one of these, you must include a curl/UI repro showing it now passes.
+
+## Reporting bugs you find that are NOT listed above
+
+- Verify it reproduces twice
+- Capture: exact request/response, screenshot, log snippet from `/tmp/hangar-restart-g.log`
+- Surface in `notes` of your test results JSON — operator decides whether to file

--- a/.pipeline/hangar-test-context.md
+++ b/.pipeline/hangar-test-context.md
@@ -88,3 +88,33 @@ If your change is the fix for one of these, you must include a curl/UI repro sho
 - Verify it reproduces twice
 - Capture: exact request/response, screenshot, log snippet from `/tmp/hangar-restart-g.log`
 - Surface in `notes` of your test results JSON — operator decides whether to file
+
+## Pipeline gates (enforced after you submit results)
+
+Two automated gates run after your test results JSON lands. If either fails, the pipeline rejects PASS regardless of what you wrote and routes the run back to the fixer.
+
+### Gate 1 — Regression smoke (always runs)
+The pipeline executes `./.pipeline/smoke.sh` after your run. It hits `/api/v1/health`, opens the dashboard via agent-browser, spawns a session, asserts HOME/TERM env are populated, verifies the session page renders the slug, and DELETEs cleanly. Smoke failure = test failure.
+
+You don't need to invoke smoke yourself; just make sure your change does not break the dashboard golden path. If your fix intentionally alters this flow, update `smoke.sh` in the same PR.
+
+### Gate 2 — Screenshot evidence (UI-surface changes only)
+If `git diff --name-only main...<branch>` includes any of `frontend/`, `backend/src/api/`, `backend/src/drivers/`, `backend/src/ws/`, your test results JSON MUST include at least one screenshot path in the `screenshots` array. Empty array on UI-surface change = pipeline rejects PASS.
+
+Take screenshots like:
+```bash
+mkdir -p /tmp/test-shots
+agent-browser screenshot --output /tmp/test-shots/dashboard.png
+```
+
+…and include the paths in your output:
+```json
+{
+  "status": "PASS",
+  "screenshots": ["/tmp/test-shots/dashboard.png", "/tmp/test-shots/session-spawn.png"],
+  ...
+}
+```
+
+### Tester model bump
+For UI-surface changes the pipeline silently bumps your model to opus regardless of `models.json`. You may notice slower runs but better instruction-following.

--- a/.pipeline/pipeline.sh
+++ b/.pipeline/pipeline.sh
@@ -293,8 +293,17 @@ if ! should_skip_step "$LOG_FILE" "tests-pass"; then
     # Test
     TEST_RESULTS="$LOGS_DIR/test-results-${FIX_ROUND}.json"
 
+    REPO_TEST_CTX_FILE="$PROJECT_DIR/.pipeline/hangar-test-context.md"
+    REPO_TEST_CTX=""
+    if [ -f "$REPO_TEST_CTX_FILE" ]; then
+      REPO_TEST_CTX=$(cat "$REPO_TEST_CTX_FILE")
+    fi
+
     run_agent "tester" "$MODEL_TESTER" \
       "Test the changes on branch $BRANCH_NAME in $PROJECT_DIR.
+
+## Repo-specific test context
+$REPO_TEST_CTX
 
 ## Plan (what was built)
 $PLAN_CONTENT

--- a/.pipeline/pipeline.sh
+++ b/.pipeline/pipeline.sh
@@ -299,7 +299,18 @@ if ! should_skip_step "$LOG_FILE" "tests-pass"; then
       REPO_TEST_CTX=$(cat "$REPO_TEST_CTX_FILE")
     fi
 
-    run_agent "tester" "$MODEL_TESTER" \
+    # Detect UI-surface changes vs main → bump tester to opus + post-test gates
+    UI_SURFACE=false
+    if git -C "$PROJECT_DIR" diff --name-only "main...$BRANCH_NAME" 2>/dev/null \
+        | grep -qE '^(frontend/|backend/src/api/|backend/src/drivers/|backend/src/ws/)'; then
+      UI_SURFACE=true
+      RUN_MODEL_TESTER="opus"
+      echo "    [pipeline] UI-surface change detected → tester=opus, smoke + screenshot gates active"
+    else
+      RUN_MODEL_TESTER="$MODEL_TESTER"
+    fi
+
+    run_agent "tester" "$RUN_MODEL_TESTER" \
       "Test the changes on branch $BRANCH_NAME in $PROJECT_DIR.
 
 ## Repo-specific test context
@@ -315,13 +326,48 @@ Write test results to: $TEST_RESULTS" "$FIX_ROUND"
     if [ ! -f "$TEST_RESULTS" ]; then
       echo "    ⚠ No test results file — assuming needs fixing"
     elif jq -e '.status == "PASS"' "$TEST_RESULTS" >/dev/null 2>&1; then
-      TESTS_PASS=true
-      log_test_result "$FIX_ROUND" true
-      echo "    ✓ Tests PASS (round $FIX_ROUND)"
+      # Hard gates — declare PASS only when:
+      #   1. Repo regression smoke succeeds (smoke.sh exists)
+      #   2. UI-surface changes carry >=1 screenshot in test results
+      GATE_PASS=true
+      GATE_NOTES=""
 
-      tmp=$(mktemp)
-      jq '.completed_steps += ["tests-pass"]' "$LOG_FILE" > "$tmp" && mv "$tmp" "$LOG_FILE"
-      continue
+      if [ -x "$PROJECT_DIR/.pipeline/smoke.sh" ]; then
+        SMOKE_DIR="$LOGS_DIR/smoke-${FIX_ROUND}"
+        echo "    [pipeline] running regression smoke → $SMOKE_DIR"
+        if "$PROJECT_DIR/.pipeline/smoke.sh" "$SMOKE_DIR" > "$SMOKE_DIR.log" 2>&1; then
+          echo "    [pipeline] smoke PASS"
+        else
+          echo "    [pipeline] smoke FAIL — see $SMOKE_DIR.log"
+          GATE_PASS=false
+          GATE_NOTES="${GATE_NOTES}smoke FAIL (see $SMOKE_DIR.log); "
+        fi
+      fi
+
+      if [ "$UI_SURFACE" = true ]; then
+        SHOTS=$(jq '(.screenshots // []) | length' "$TEST_RESULTS" 2>/dev/null || echo 0)
+        if [ "$SHOTS" -lt 1 ]; then
+          echo "    [pipeline] UI-surface change but tester provided $SHOTS screenshots — rejecting PASS"
+          GATE_PASS=false
+          GATE_NOTES="${GATE_NOTES}UI-surface change requires >=1 screenshot, got $SHOTS; "
+        fi
+      fi
+
+      if [ "$GATE_PASS" = true ]; then
+        TESTS_PASS=true
+        log_test_result "$FIX_ROUND" true
+        echo "    ✓ Tests PASS (round $FIX_ROUND)"
+
+        tmp=$(mktemp)
+        jq '.completed_steps += ["tests-pass"]' "$LOG_FILE" > "$tmp" && mv "$tmp" "$LOG_FILE"
+        continue
+      else
+        tmp=$(mktemp)
+        jq --arg notes "$GATE_NOTES" '.pipeline_gate_failure = $notes | .status = "FAIL"' \
+          "$TEST_RESULTS" > "$tmp" && mv "$tmp" "$TEST_RESULTS"
+        log_test_result "$FIX_ROUND" false
+        echo "    ✗ Pipeline gates FAIL (round $FIX_ROUND/$MAX_FIX_ROUNDS): $GATE_NOTES"
+      fi
     else
       log_test_result "$FIX_ROUND" false
       echo "    ✗ Tests FAIL (round $FIX_ROUND/$MAX_FIX_ROUNDS)"

--- a/.pipeline/smoke.sh
+++ b/.pipeline/smoke.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# hangar regression smoke — runs agent-browser through the dashboard
+# golden path. Exits non-zero on any failure so the pipeline can treat
+# it as a test failure and route to fixer.
+#
+# Usage: ./.pipeline/smoke.sh [output-dir]
+#   output-dir defaults to /tmp/hangar-smoke-$(date +%s)
+set -uo pipefail
+
+OUT_DIR="${1:-/tmp/hangar-smoke-$(date +%s)}"
+mkdir -p "$OUT_DIR"
+
+DASHBOARD_URL="${HANGAR_DASHBOARD_URL:-http://localhost:5173}"
+API_URL="${HANGAR_API_URL:-http://localhost:3000/api/v1}"
+SLUG="smoke-pipeline-$(date +%s)-$RANDOM"
+
+export PATH="$HOME/.npm-global/bin:$PATH"
+
+fail() {
+  echo "[smoke] FAIL: $*" >&2
+  agent-browser close >/dev/null 2>&1 || true
+  curl -s -o /dev/null -X DELETE "$API_URL/sessions/$SLUG" || true
+  exit 1
+}
+
+step() { echo "[smoke] $*"; }
+
+# Pre-flight — JSON parse via python to avoid quote hell
+step "pre-flight: api health"
+H=$(curl -s --max-time 3 "$API_URL/health" || echo "")
+[ -n "$H" ] || fail "health endpoint unreachable"
+python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.argv[1])
+except Exception as e:
+    sys.exit(f'health response not JSON: {e}')
+if d.get('status') != 'ok':
+    sys.exit(f'status != ok: {d}')
+if not d.get('supervisor_connected'):
+    sys.exit(f'supervisor not connected: {d}')
+" "$H" || fail "health JSON failed: $H"
+
+# Open dashboard
+step "open dashboard"
+agent-browser open "$DASHBOARD_URL" --args "--no-sandbox --headless" \
+  > "$OUT_DIR/01-open.txt" 2>&1 || fail "agent-browser open failed (see $OUT_DIR/01-open.txt)"
+
+# Wait for SvelteKit hydration — vite dev server can take a sec on first paint
+step "wait for dashboard to render"
+for i in 1 2 3 4 5 6 7 8; do
+  agent-browser snapshot > "$OUT_DIR/02-dashboard.snap" 2>&1 || true
+  if grep -q "Hangar" "$OUT_DIR/02-dashboard.snap" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+grep -q "Hangar" "$OUT_DIR/02-dashboard.snap" || fail "Hangar header not in dashboard snapshot"
+grep -q "New Session" "$OUT_DIR/02-dashboard.snap" || fail "New Session button missing"
+agent-browser screenshot --output "$OUT_DIR/02-dashboard.png" >/dev/null 2>&1 || true
+
+# Spawn session via API (bypass modal — modal can be in deeper tester suites later)
+step "spawn session $SLUG via API"
+SPAWN_RESP=$(curl -s -X POST "$API_URL/sessions" \
+  -H "Content-Type: application/json" \
+  -d "{\"slug\":\"$SLUG\",\"kind\":{\"type\":\"shell\"}}")
+SESSION_ID=$(python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.argv[1])
+    print(d.get('id', ''))
+except Exception:
+    pass
+" "$SPAWN_RESP")
+[ -n "$SESSION_ID" ] || fail "spawn API returned: $SPAWN_RESP"
+sleep 1
+
+# Visit session page
+step "navigate to session page"
+agent-browser open "$DASHBOARD_URL/session/$SESSION_ID" --args "--no-sandbox --headless" \
+  > "$OUT_DIR/03-session-open.txt" 2>&1 || fail "session open failed"
+for i in 1 2 3 4 5 6 7 8; do
+  agent-browser snapshot > "$OUT_DIR/04-session.snap" 2>&1 || true
+  if grep -q "$SLUG" "$OUT_DIR/04-session.snap" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+grep -q "$SLUG" "$OUT_DIR/04-session.snap" || fail "session slug $SLUG not visible on session page"
+agent-browser screenshot --output "$OUT_DIR/04-session.png" >/dev/null 2>&1 || true
+
+# Verify env-fix shipped: shell prompt should show /home/george, not empty path
+step "verify env fix (HOME populated in PTY)"
+sleep 2
+PROBE_FILE="/tmp/smoke-probe-$SLUG.out"
+rm -f "$PROBE_FILE"
+PROMPT_HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "$API_URL/sessions/$SLUG/prompt" \
+  -H "Content-Type: application/json" \
+  -d "{\"text\":\"echo ENV_HOME=[\$HOME] ENV_TERM=[\$TERM] > $PROBE_FILE\"}")
+[ "$PROMPT_HTTP" = "204" ] || fail "prompt POST returned $PROMPT_HTTP"
+sleep 2
+PTY_OUT=$(cat "$PROBE_FILE" 2>/dev/null || echo "")
+echo "$PTY_OUT" | grep -q "ENV_HOME=\[/home/george\]" || fail "HOME not populated in PTY: '$PTY_OUT'"
+echo "$PTY_OUT" | grep -q "ENV_TERM=\[xterm" || fail "TERM not xterm-*: '$PTY_OUT'"
+
+# Cleanup: DELETE the smoke session
+step "cleanup: DELETE $SLUG"
+DEL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/sessions/$SLUG")
+[ "$DEL_HTTP" = "204" ] || fail "DELETE returned $DEL_HTTP (expected 204)"
+
+# Cleanup any other smoke-pipeline-* sessions
+curl -s "$API_URL/sessions" | python3 -c "
+import sys, json
+for s in json.load(sys.stdin):
+  if s['slug'].startswith('smoke-pipeline-'):
+    print(s['slug'])
+" | while read STALE; do
+  curl -s -o /dev/null -X DELETE "$API_URL/sessions/$STALE" || true
+done
+
+agent-browser close >/dev/null 2>&1 || true
+rm -f "$PROBE_FILE"
+
+step "smoke PASS — artifacts in $OUT_DIR"
+exit 0


### PR DESCRIPTION
## Summary

Locks down hangar UI testing in the pipeline from prompt-only to **actually enforced**.

### Files
- `.pipeline/hangar-test-context.md` — hangar-specific tester playbook (live URLs, UI mandate, regression smoke, agent-browser cheatsheet, cleanup recipe, known-bug list, **pipeline-gates section**).
- `.pipeline/smoke.sh` (new, executable) — agent-browser regression smoke. Hits health, opens dashboard, spawns a session, asserts HOME/TERM populated (regression for the #66 driver fix), navigates to the session page, asserts slug renders, DELETEs cleanly, reaps stragglers.
- `.pipeline/pipeline.sh` — three changes:
  1. **UI-surface detection** via `git diff --name-only main...<branch>` for `frontend/`, `backend/src/api/`, `backend/src/drivers/`, `backend/src/ws/`
  2. **Tester model bump to opus** when UI-surface (regardless of models.json)
  3. **Two hard gates** after tester returns PASS:
     - **Gate 1 (always):** `./.pipeline/smoke.sh` runs; failure routes to fixer with notes appended to test-results JSON
     - **Gate 2 (UI-surface only):** `.screenshots` array length must be >=1; empty routes to fixer

## Why
Tester agent had `agent-browser` available but was free to skip it. The original chore/pipeline-ui-test-playbook commit was a soft mandate (prompt only) — pushed in the first commit on this branch. After the operator asked for maximum coverage, gates were added to make API-only PASS impossible for any UI-surface change.

## Test plan
- [x] Verified `agent-browser` works against live dashboard (snapshot rendered correct accessibility tree)
- [x] Verified `smoke.sh` end-to-end on box — exits 0 on healthy stack
- [x] Verified `pipeline.sh` shell syntax (`bash -n`)
- [x] Verified UI-surface regex catches `frontend/`, `backend/src/api/`, `backend/src/drivers/`, `backend/src/ws/`
- [ ] Reviewer dry-run on any open issue — confirm tester actually takes screenshots and smoke runs

## Cost note
Smoke runs every test round. If a fix takes N rounds, smoke runs N times. Each smoke is ~6s of agent-browser + ~2 curl. Negligible.