### PR TITLE
chore(pipeline): batch.sh skips needs-investigation label by default

### DIFF
--- a/.pipeline/batch.sh
+++ b/.pipeline/batch.sh
@@ -11,12 +11,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(pwd)"
 ISSUES=""
 ALL_OPEN=false
+EXCLUDE_LABEL="needs-investigation"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --project-dir) PROJECT_DIR="$2"; shift 2 ;;
-    --issues) ISSUES="$2"; shift 2 ;;
-    --all-open) ALL_OPEN=true; shift ;;
+    --project-dir)    PROJECT_DIR="$2"; shift 2 ;;
+    --issues)         ISSUES="$2"; shift 2 ;;
+    --all-open)       ALL_OPEN=true; shift ;;
+    --exclude-label)  EXCLUDE_LABEL="$2"; shift 2 ;;
+    --no-exclude)     EXCLUDE_LABEL=""; shift ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
   esac
 done
@@ -25,7 +28,12 @@ REPO_SLUG=$(git -C "$PROJECT_DIR" remote get-url origin | sed 's|.*github.com[:/
 
 # Get issue list
 if [ "$ALL_OPEN" = true ]; then
-  ISSUE_LIST=$(gh issue list --repo "$REPO_SLUG" --state open --json number -q '.[].number' | sort -n)
+  if [ -n "$EXCLUDE_LABEL" ]; then
+    ISSUE_LIST=$(gh issue list --repo "$REPO_SLUG" --search "is:open -label:$EXCLUDE_LABEL" --json number -q '.[].number' | sort -n)
+    echo "[batch] excluding issues labeled: $EXCLUDE_LABEL (override with --exclude-label X or --no-exclude)"
+  else
+    ISSUE_LIST=$(gh issue list --repo "$REPO_SLUG" --state open --json number -q '.[].number' | sort -n)
+  fi
 elif [ -n "$ISSUES" ]; then
   ISSUE_LIST=$(echo "$ISSUES" | tr ',' '\n')
 else


### PR DESCRIPTION
## Summary
- Add `--exclude-label` flag to `.pipeline/batch.sh` (default: `needs-investigation`).
- `--all-open` now filters out issues with that label.
- Override with `--exclude-label X` or `--no-exclude`.
- Created `needs-investigation` label in repo and applied to #57.

## Why
Some bugs (e.g. #57 SQLite malformed code 267) need human-led debugging — the on-disk DB is healthy (`PRAGMA integrity_check: ok`) but hangard's delete code path returns 500. Speculative auto-fixes from the pipeline would burn token budget and could submit a wrap-in-try/catch fix that hides the real bug. Labeling the issue + auto-skipping in batch makes this protection durable across operator handoffs.

## Test plan
- [x] `bash -n batch.sh` syntax check
- [x] Manual: `gh issue list --search "is:open -label:needs-investigation"` returns expected set
- [x] Label created, applied to #57
- [ ] Reviewer dry-run when next batch runs
