### PR TITLE
feat: Cost/ctx sidebar lags real CTX line + mislabels output tokens

### DIFF
--- a/backend/src/drivers/mod.rs
+++ b/backend/src/drivers/mod.rs
@@ -21,10 +21,16 @@ pub mod status_scraper {
         .unwrap()
     });
 
+    /// Re-emit even when values are unchanged to keep polling-driven UI fresh.
+    /// Bounds storage at ~30 rows/min/session when idle.
+    const STATUS_HEARTBEAT_MS: u64 = 2000;
+
     #[derive(Default)]
     pub struct ScraperState {
         pub last_dollars: Option<f64>,
         pub last_pct: Option<u32>,
+        pub last_tokens_k: Option<u64>,
+        pub last_emit_ms: Option<u64>,
         pub last_model: Option<String>,
         pub line_buf: String,
         pub status_buf: String,
@@ -53,10 +59,19 @@ pub mod status_scraper {
             let pct: u32 = cap[1].parse().unwrap_or(0);
             let tokens_k: u64 = cap[2].parse().unwrap_or(0);
             let dollars: f64 = cap[3].parse().unwrap_or(0.0);
-            let changed = state.last_dollars != Some(dollars) || state.last_pct != Some(pct);
-            if changed {
+            let now = util::now_ms();
+            let values_changed = state.last_dollars != Some(dollars)
+                || state.last_pct != Some(pct)
+                || state.last_tokens_k != Some(tokens_k);
+            let heartbeat_due = match state.last_emit_ms {
+                Some(t) => now.saturating_sub(t) >= STATUS_HEARTBEAT_MS,
+                None => true,
+            };
+            if values_changed || heartbeat_due {
                 state.last_dollars = Some(dollars);
                 state.last_pct = Some(pct);
+                state.last_tokens_k = Some(tokens_k);
+                state.last_emit_ms = Some(now);
                 events.push(AgentEvent::ContextWindowSizeChanged {
                     pct_used: pct as f32 / 100.0,
                     tokens: tokens_k * 1000,
@@ -110,6 +125,58 @@ pub mod status_scraper {
         }
 
         events
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::util;
+
+        const STATUS_LINE: &str = "CTX 3% 30k $0.11 | foo | claude-opus-4-7 |";
+
+        #[test]
+        fn scrape_status_emits_on_first_match() {
+            let mut state = ScraperState::default();
+            let evs = scrape_status(STATUS_LINE, &mut state);
+            assert_eq!(evs.len(), 3); // ctx + cost + model
+        }
+
+        #[test]
+        fn scrape_status_suppresses_duplicate_within_heartbeat() {
+            let mut state = ScraperState::default();
+            scrape_status(STATUS_LINE, &mut state);
+            // Second call immediately — heartbeat not due, values unchanged.
+            let evs = scrape_status(STATUS_LINE, &mut state);
+            assert_eq!(evs.len(), 0);
+        }
+
+        #[test]
+        fn scrape_status_emits_on_value_change() {
+            let mut state = ScraperState::default();
+            scrape_status(STATUS_LINE, &mut state);
+            let evs = scrape_status("CTX 3% 30k $0.22 | foo | claude-opus-4-7 |", &mut state);
+            // dollars changed → ctx + cost events
+            assert!(evs.len() >= 2);
+        }
+
+        #[test]
+        fn scrape_status_heartbeat_reemits_after_window() {
+            let mut state = ScraperState::default();
+            scrape_status(STATUS_LINE, &mut state);
+            // Backdate last_emit_ms past the heartbeat window.
+            state.last_emit_ms = Some(util::now_ms().saturating_sub(STATUS_HEARTBEAT_MS + 100));
+            let evs = scrape_status(STATUS_LINE, &mut state);
+            assert!(evs.len() >= 2);
+        }
+
+        #[test]
+        fn scrape_status_emits_when_tokens_change_but_pct_unchanged() {
+            let mut state = ScraperState::default();
+            scrape_status("CTX 3% 30k $0.11 | foo | claude-opus-4-7 |", &mut state);
+            // tokens_k changes (32 vs 30), pct stays 3%
+            let evs = scrape_status("CTX 3% 32k $0.11 | foo | claude-opus-4-7 |", &mut state);
+            assert!(evs.len() >= 2);
+        }
     }
 }
 

--- a/frontend/src/lib/components/InsightsPanel.svelte
+++ b/frontend/src/lib/components/InsightsPanel.svelte
@@ -45,7 +45,9 @@
 	<div class="section">
 		<div class="heading">Cost (est.)</div>
 		<div class="cost-value">${eventsStore.outputCost.estimatedCost.toFixed(4)}</div>
-		<div class="muted">{eventsStore.outputCost.totalTokens.toLocaleString()} output tokens</div>
+		{#if eventsStore.outputCost.outputTokens > 0}
+			<div class="muted">{eventsStore.outputCost.outputTokens.toLocaleString()} output tokens</div>
+		{/if}
 		{#if eventsStore.outputCost.model}
 			<div class="muted mono small">{eventsStore.outputCost.model}</div>
 		{/if}

--- a/frontend/src/lib/stores/events.svelte.ts
+++ b/frontend/src/lib/stores/events.svelte.ts
@@ -137,26 +137,23 @@ const OUTPUT_RATES: Record<string, number> = {
 const DEFAULT_OUTPUT_RATE = 15 / 1000;
 
 function computeOutputCost(evs: StoredEvent[]): {
-	totalTokens: number;
+	outputTokens: number;
 	estimatedCost: number;
 	model: string | null;
 } {
-	let totalTokens = 0;
+	let outputTokens = 0;
 	let model: string | null = null;
 	let authoritativeCost: number | null = null;
-	let ctxTokens: number | null = null;
 
 	for (const storedEv of evs) {
 		if (storedEv.event.type !== 'agent_event') continue;
 		const ae: AgentEvent = storedEv.event.event;
 		if (ae.type === 'turn_finished') {
-			totalTokens += ae.tokens_used;
+			outputTokens += ae.tokens_used;
 		} else if (ae.type === 'model_changed') {
 			model = ae.model;
 		} else if (ae.type === 'cost_updated') {
 			authoritativeCost = ae.dollars;
-		} else if (ae.type === 'context_window_size_changed') {
-			ctxTokens = ae.tokens;
 		}
 	}
 
@@ -165,10 +162,9 @@ function computeOutputCost(evs: StoredEvent[]): {
 		: undefined;
 	const rate = rateKey ? OUTPUT_RATES[rateKey] : DEFAULT_OUTPUT_RATE;
 	const estimatedCost =
-		authoritativeCost !== null ? authoritativeCost : (totalTokens / 1000) * rate;
-	const displayTokens = ctxTokens !== null ? ctxTokens : totalTokens;
+		authoritativeCost !== null ? authoritativeCost : (outputTokens / 1000) * rate;
 
-	return { totalTokens: displayTokens, estimatedCost, model };
+	return { outputTokens, estimatedCost, model };
 }
 
 function findCurrentModel(evs: StoredEvent[]): string | null {


### PR DESCRIPTION
Closes #60

## Pipeline Run
- Plan: plan-v1.md
- Review rounds: 1
- Test rounds: 1
- Status: All tests passing

Logs: `pipeline-logs/issue-60/issue-60/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Implemented heartbeat monitoring for more responsive token count tracking and status updates
  * Output tokens now display only when generated, reducing unnecessary UI clutter
  * Cost calculations refined to track output tokens exclusively for greater accuracy
  * System emits updates based on token changes and periodic time intervals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->