### PR TITLE
feat(deploy): containerize for OrbStack on Mac mini (ADR-0017)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Build artifacts
+backend/target
+frontend/node_modules
+frontend/build
+frontend/.svelte-kit
+
+# VCS
+.git
+.gitignore
+
+# Local / editor / OS
+.DS_Store
+.vscode
+.idea
+*.swp
+
+# Docs / non-code (keep build context lean)
+docs
+prompts
+caddy
+systemd
+web
+.pipeline
+pipeline-logs
+*.md
+!README.md
+
+# State / logs that shouldn't ever ship
+**/*.log
+**/.local
+**/.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `deploy/docker/Dockerfile` — multi-stage build: Rust release binaries + frontend bundle into a Debian-slim runtime with Caddy.
+- `deploy/docker/compose.yml` — local + cloud-VM deployment recipe. Named volume for state, host port `:8080` published.
+- `deploy/docker/entrypoint.sh` — starts supervisor + Caddy + hangard inside the container.
+- `deploy/docker/Caddyfile` — container-internal reverse proxy (replaces the host Caddy install).
+- `scripts/deploy.sh container build|up|down|logs` — primary local workflow.
+- ADR-0017 — containerized deployment, OrbStack on the Mac mini host.
+
+### Changed
+
+- Host migration: retired the Dell OptiPlex 7050. New host is `george-mac-mini` (Apple M4, 24 GB RAM, macOS) running OrbStack.
+- `README.md` + `docs/ARCHITECTURE.md` updated to reflect container-first deployment model.
+- `scripts/deploy.sh backend` subcommand kept for the cloud-VM-with-systemd path; default local path is now `container`.
+
+### Deprecated
+
+- Issues #88 (sandbox `cfg(target_os = "linux")` gate) and #89 (launchd plists) — deprioritized but not closed. Only matter if a future native-macOS build path is wanted; the container is the canonical artifact.
+
 ## [0.2.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # hangar
 
-**Personal agent operating system.** A self-hosted control plane for AI coding agents (Claude Code, Codex, and others), running on a dedicated always-on box. Think `tmux + kubectl + OBS` reimagined for someone who lives inside multiple Claude sessions.
+**Personal agent operating system.** A self-hosted control plane for AI coding agents (Claude Code, Codex, and others), shipped as a Linux container that runs locally under OrbStack on a Mac and identically on any cloud Linux VM. Think `tmux + kubectl + OBS` reimagined for someone who lives inside multiple Claude sessions.
 
-Status: early. Phase 0 shipped (ttyd + caddy stopgap dashboard). Phase 1+ in planning. See [docs/ROADMAP.md](docs/ROADMAP.md).
+Status: v0.2.0 shipped Phase 2 MVP (Rust backend, SvelteKit dashboard, ntfy push, REST prompt API). Now migrating from the original optiplex host to a containerized deploy on the Mac mini ([ADR-0017](docs/decisions/0017-containerize-deployment.md)).
 
 ---
 
@@ -25,23 +25,32 @@ hangar is the tool that sits above tmux (and later replaces it) to give you a re
 ## Who this is for
 
 - Solo developers running multi-session AI-agent workflows
-- Anyone who has a dedicated always-on box (home server, cloud VM) and a laptop/phone they hop between
+- Anyone who has an always-on box (Mac mini, home server, cloud VM) and a laptop/phone they hop between
 - People who want to build on top of a typed session/agent model rather than scrape ANSI terminal bytes
 
 Not for: shared team installs, multi-tenant SaaS, or people who are happy with a single terminal window.
 
 ---
 
-## What's here today (Phase 0)
+## What's here today (v0.2.0, containerizing in progress)
 
 ```
-./caddy/Caddyfile           Reverse proxy :8080 → ttyd backends + static dashboard
-./systemd/ttyd-*.service    One ttyd per tmux session (codex, wave, issue12)
-./web/index.html            Static dashboard: tabs, grid view, reload buttons
-./scripts/deploy.sh         Installs units, reloads caddy
+./backend/                  Rust backend (hangard + hangar-supervisor)
+./frontend/                 SvelteKit SPA dashboard
+./caddy/Caddyfile           Reverse proxy :8080 → backend + static dashboard
+./deploy/docker/            Dockerfile + compose.yml for the containerized deploy
+./scripts/deploy.sh         container build/up/down (local) and backend (legacy systemd)
 ```
 
-Served at `http://optiplex:8080` on the tailnet. Per-session iframe at `/s/<name>/`.
+Run it locally:
+
+```bash
+./scripts/deploy.sh container build
+./scripts/deploy.sh container up
+open http://localhost:8080
+```
+
+Same compose file runs on any cloud Linux VM with Docker.
 
 ---
 
@@ -71,16 +80,17 @@ Agents working in this repo: read `ARCHITECTURE.md` then the current phase doc i
 
 ## Working in this repo
 
-Primary environment is the Optiplex box (tailnet host `optiplex`). See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#environment) for the deployment model. Backend code will be Rust; frontend is SvelteKit (incoming in Phase 2). Phase 0 is plain HTML.
+Primary host is `george-mac-mini` running OrbStack. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#environment) for the deployment model. Backend is Rust (`hangard`, `hangar-supervisor`), frontend is SvelteKit, both built into a single Linux container image.
 
 Local dev workflow:
 
 ```
-laptop: edit → commit → push to github.com/georgenijo/hangar
-box:    git pull → cargo build --release → systemctl restart hangar
+edit → commit → push to github.com/georgenijo/hangar
+./scripts/deploy.sh container build
+./scripts/deploy.sh container up
 ```
 
-Specifics land in each phase doc.
+Cloud VM workflow: same `Dockerfile`, deploy via `docker compose up -d`. See [`docs/decisions/0017-containerize-deployment.md`](docs/decisions/0017-containerize-deployment.md) for rationale. Specifics land in each phase doc.
 
 ---
 

--- a/deploy/docker/Caddyfile
+++ b/deploy/docker/Caddyfile
@@ -1,0 +1,22 @@
+:8080 {
+	encode gzip
+
+	handle /api/* {
+		reverse_proxy localhost:3000
+	}
+
+	handle /ws/* {
+		reverse_proxy localhost:3000
+	}
+
+	handle {
+		root * /var/www/hangar
+		try_files {path} /index.html
+		file_server
+	}
+
+	log {
+		output stdout
+		format console
+	}
+}

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.7
+
+# ===== rust-build =====
+FROM rust:1-bookworm AS rust-build
+WORKDIR /src
+COPY backend/Cargo.toml backend/Cargo.lock ./backend/
+COPY backend/migrations ./backend/migrations
+COPY backend/src ./backend/src
+COPY backend/tests ./backend/tests
+WORKDIR /src/backend
+RUN cargo build --release --bins
+
+# ===== frontend-build =====
+FROM node:22-bookworm-slim AS frontend-build
+RUN npm install -g pnpm@9.12.0
+WORKDIR /src/frontend
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY frontend/ ./
+RUN pnpm build
+
+# ===== runtime =====
+FROM debian:bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl bash bash-completion less vim-tiny git tini procps \
+    debian-keyring debian-archive-keyring apt-transport-https gnupg \
+    && curl -fsSL "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
+    && curl -fsSL "https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt" > /etc/apt/sources.list.d/caddy-stable.list \
+    && apt-get update && apt-get install -y --no-install-recommends caddy \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g --omit=dev @anthropic-ai/claude-code @openai/codex \
+    && npm cache clean --force
+
+COPY --from=rust-build /src/backend/target/release/hangard /usr/local/bin/hangard
+COPY --from=rust-build /src/backend/target/release/hangar-supervisor /usr/local/bin/hangar-supervisor
+COPY --from=frontend-build /src/frontend/build /var/www/hangar
+COPY deploy/docker/Caddyfile /etc/caddy/Caddyfile
+COPY deploy/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Non-root user so `claude --dangerously-skip-permissions` and similar tools
+# that refuse to run as root work cleanly. UID 1000 is the Linux convention.
+RUN useradd -m -u 1000 -s /bin/bash hangar \
+    && mkdir -p /state \
+    && chown -R hangar:hangar /state /home/hangar
+USER hangar
+# Default cwd for spawned sessions. `/code` is where the host's
+# ~/Documents/code bind mount lands, so sessions start sitting in the
+# projects parent dir and the user is one `cd <project>` away.
+WORKDIR /code
+
+ENV HANGAR_STATE_DIR=/state \
+    HANGAR_PORT=3000 \
+    HOME=/home/hangar \
+    SHELL=/bin/bash \
+    TERM=xterm-256color \
+    RUST_LOG=info
+EXPOSE 8080
+VOLUME ["/state"]
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -1,0 +1,38 @@
+name: hangar
+
+services:
+  hangar:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    image: hangar:dev
+    container_name: hangar
+    ports:
+      - "8080:8080"
+    volumes:
+      - hangar-state:/state
+      # Container's own persistent home dir. Claude Code config, OAuth tokens,
+      # project history, codex config, gh state, ssh keys, etc. all live here
+      # and survive container rebuilds. Auth happens inside the container via
+      # `/login` once — host macOS Keychain (where Claude Max creds live) is
+      # not reachable from a Linux container, so the container does its own
+      # OAuth.
+      - hangar-home:/home/hangar
+      # User code visible inside the container under /code so agents can edit it.
+      # Anything written here lands on the host at ~/Documents/code/...
+      - ${HOME}/Documents/code:/code
+    environment:
+      - HANGAR_PORT=3000
+      - HANGAR_STATE_DIR=/state
+      - RUST_LOG=info
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/v1/metrics"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+volumes:
+  hangar-state:
+  hangar-home:

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Entrypoint for the hangar container.
+# Starts the supervisor (holds PTY fds), then Caddy (serves SPA + proxies API),
+# then runs hangard in the foreground. tini (PID 1) reaps zombies and forwards
+# signals.
+set -euo pipefail
+
+STATE_DIR="${HANGAR_STATE_DIR:-/state}"
+mkdir -p "$STATE_DIR/sessions"
+
+echo "[entrypoint] starting hangar-supervisor"
+/usr/local/bin/hangar-supervisor &
+SUPERVISOR_PID=$!
+
+# Give supervisor a moment to create its Unix socket
+for i in 1 2 3 4 5 6 7 8 9 10; do
+	if [ -S "$STATE_DIR/hangar/supervisor.sock" ] || [ -S "$STATE_DIR/supervisor.sock" ]; then
+		break
+	fi
+	sleep 0.2
+done
+
+echo "[entrypoint] starting caddy"
+caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
+CADDY_PID=$!
+
+cleanup() {
+	echo "[entrypoint] shutting down"
+	kill -TERM "$CADDY_PID" 2>/dev/null || true
+	kill -TERM "$SUPERVISOR_PID" 2>/dev/null || true
+	wait 2>/dev/null || true
+}
+trap cleanup TERM INT
+
+echo "[entrypoint] starting hangard"
+exec /usr/local/bin/hangard

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ One-page system design. Written for humans and for AI agents working in this rep
 
 ## Elevator pitch
 
-hangar is a single-binary Rust backend that owns terminal sessions (PTYs), wraps known agents (Claude Code, Codex, shell) with smart drivers, and exposes a REST + WebSocket API. A SvelteKit frontend renders a command-center dashboard. The stack runs on a dedicated box reachable over Tailscale today and via Cloudflare Tunnel with SSO later.
+hangar is a single-binary Rust backend that owns terminal sessions (PTYs), wraps known agents (Claude Code, Codex, shell) with smart drivers, and exposes a REST + WebSocket API. A SvelteKit frontend renders a command-center dashboard. The whole stack ships as a Linux container that runs locally under OrbStack on a Mac mini today, and identically on any cloud Linux VM (AWS EC2, Oracle Cloud, etc.) — see [ADR-0017](decisions/0017-containerize-deployment.md). Public access is via Cloudflare Tunnel with SSO.
 
 ---
 
@@ -125,15 +125,15 @@ Backups: add these paths to the box's existing restic job.
 
 ## Process model
 
-Single Rust binary `hangard` runs under systemd as user `george`. Responsibilities:
+Inside the container, three processes run side-by-side (started by `deploy/docker/entrypoint.sh`):
 
-1. **HTTP server** (axum + tokio) on `localhost:3000`
-2. **PTY supervisor**: spawns child processes, streams I/O, monitors exit
-3. **Agent drivers** run as async tasks per session, parsing output, emitting structured events
-4. **Event bus**: `tokio::sync::broadcast` channel fan-out to WebSocket subscribers + persistent log writer + push dispatcher
-5. **Metrics + logs**: logs to stdout (systemd captures to journald), metrics at `/api/metrics`
+1. **`hangar-supervisor`** — holds PTY file descriptors over a Unix socket so sessions survive `hangard` restarts ([ADR-0010](decisions/0010-sessions-survive-restart.md))
+2. **`hangard`** — HTTP server (axum + tokio) on `:3000`, PTY spawn/IO via the supervisor socket, agent drivers, event bus, SQLite + ring-buffer writes
+3. **`caddy`** — reverse proxy on `:8080`, serves the SvelteKit SPA and routes `/api/*` + `/ws/*` to `hangard`
 
-**Crash recovery**: on restart, backend scans SQLite for sessions in non-terminal states. A small supervisor daemon (or systemd-managed re-parenting) holds PTY fds via Unix socket so sessions survive backend restarts. See [ADR-0010](decisions/0010-sessions-survive-restart.md).
+Only port `:8080` is published to the host. State (`hangar.db`, ring files, supervisor socket) lives in a named volume mounted at `/state`. The backend honors `HANGAR_STATE_DIR` so paths stay clean.
+
+**Crash recovery**: within the container, supervisor + backend retain the existing pattern — backend can crash and reconnect to supervisor without losing PTYs. If the container itself is killed (`docker stop`, host reboot), sessions reset; the SPA reconnects automatically on the next launch.
 
 ---
 
@@ -192,11 +192,15 @@ See [ADR-0006](decisions/0006-no-sandbox-mvp.md) and the sandbox phase doc.
 
 ## Environment
 
-- **Host**: Dell OptiPlex 7050, i5-7500T, 8 GB RAM, 500 GB HDD, Ubuntu 24.04
-- **Tailnet hostname**: `optiplex` (IP 100.103.161.109)
-- **User**: `george` (passwordless sudo)
-- **Existing services**: tmux `work` session, cockpit on `:9090`, ttyd on `:7681`, restic backups
-- **New services** (Phase 0+): ttyd-codex/wave/issue12 systemd units, caddy on `:8080`
+- **Host**: `george-mac-mini` — Apple M4, 24 GB RAM, macOS
+- **Runtime**: [OrbStack](https://orbstack.dev) — Linux container engine on macOS
+- **Image**: built from `deploy/docker/Dockerfile`, runs under Docker / OrbStack / Podman
+- **State**: named volume `hangar-state` → container `/state`
+- **Published port**: `:8080` (Caddy)
+- **Public access**: Cloudflare Tunnel (Phase 1) — repointed from the retired optiplex host to the Mac mini
+- **Cloud VM compatibility**: the same image runs on any Linux VM (AWS EC2, Oracle Cloud free tier, Hetzner, Fly) via `docker compose up -d`
+
+The Dell OptiPlex 7050 that hosted v0.1.0–v0.2.0 is retired ([ADR-0017](decisions/0017-containerize-deployment.md)).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,4 +92,5 @@ Each phase has its own `docs/phases/<NN>-*.md` with explicit acceptance criteria
 3. **Every deferred feature gets an issue** — so nothing quietly disappears
 4. **Document choices as ADRs** — future Claude sessions should be able to understand "why" without asking
 5. **Tmux keeps running** during the whole build — the stopgap dashboard is kept working until hangar's own UI fully replaces it
+6. **One artifact, many hosts** — hangar ships as a Linux container image. The Mac mini under OrbStack is the daily host; any cloud Linux VM is a drop-in alternative. See [ADR-0017](decisions/0017-containerize-deployment.md).
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -4,11 +4,40 @@ How to operate the autonomous build and the running system.
 
 ---
 
-## Starting the autonomous build (on the box)
+## Running hangar locally (Mac mini, OrbStack)
+
+```bash
+# from the repo root
+./scripts/deploy.sh container build   # build image
+./scripts/deploy.sh container up      # start supervisor + hangard + caddy
+open http://localhost:8080            # dashboard
+
+./scripts/deploy.sh container logs    # tail logs
+./scripts/deploy.sh container down    # stop
+```
+
+State (SQLite + ring files) persists in the named Docker volume `hangar-state`
+across rebuilds. To wipe state: `docker volume rm hangar-state`.
+
+## Running hangar on a cloud Linux VM
+
+Same image, same compose file. On the VM:
+
+```bash
+git clone https://github.com/georgenijo/hangar.git
+cd hangar
+docker compose -f deploy/docker/compose.yml up -d
+```
+
+Cloudflare Tunnel terminates in front of the published `:8080` (run
+`cloudflared` on the VM host, or add a sidecar container).
+
+---
+
+## Starting the autonomous build
 
 ### Prerequisites
-- Box reachable over Tailscale (`ssh george@optiplex` works)
-- `~/Documents/hangar` cloned and on `main`
+- `~/Documents/code/hangar` cloned and on `main`
 - `claude` CLI authenticated (`claude /login`)
 - `gh` CLI authenticated
 - At least one tmux session named `hangar-build` for visibility
@@ -16,15 +45,13 @@ How to operate the autonomous build and the running system.
 ### Kick-off
 
 ```bash
-# on the box
-cd ~/Documents/hangar
+cd ~/Documents/code/hangar
 git pull
 
-# Start a tmux session so the build survives SSH disconnect
+# Start a tmux session so the build survives terminal disconnect
 tmux new-session -d -s hangar-build
 
 # Dispatch the pipeline in build order:
-# Phase 1 → Phase 2.1..2.4 → Phase 2.5..2.6 → Phase 2.7 → Phase 2.8
 tmux send-keys -t hangar-build \
   './.pipeline/batch.sh --project-dir "$PWD" --issues 1,6,7,8,9,2,3,10,4' Enter
 ```
@@ -32,23 +59,23 @@ tmux send-keys -t hangar-build \
 Watch via:
 - `tmux attach -t hangar-build` to see live output
 - `~/Documents/pipeline-logs/hangar/issue-<N>/` for per-issue artifacts
-- The Phase 0 dashboard (`http://optiplex:8080`) for the tmux session containing Claude agents
+- The hangar dashboard at `http://localhost:8080` for live session view
 - GitHub notifications for PRs/issue comments
 
 ### Parallel dispatch (faster)
 
 Once the serial pipeline proves out, use `parallel.sh` to run multiple issues
 concurrently — each in its own git worktree + tmux session. Same total token
-cost, ~3× faster wall-clock on this box.
+cost, ~3× faster wall-clock on the Mac mini.
 
 ```bash
-cd ~/Documents/hangar
+cd ~/Documents/code/hangar
 ./.pipeline/parallel.sh --project-dir "$PWD" --issues 6,7,8,9 --concurrent 3
 ```
 
 Sessions are named `hangar-pipe-<issue>`. Attach any one with
 `tmux attach -t hangar-pipe-6`. Worktrees live at
-`~/Documents/hangar.worktrees/issue-<N>/`.
+`~/Documents/code/hangar.worktrees/issue-<N>/`.
 
 Do **not** parallelize issues with a strong ordering dependency (e.g. run Phase 1
 alone before Phase 2.1 because 2.7 wants the tunnel); batch unrelated milestones
@@ -60,7 +87,7 @@ are rare because they touch different modules.
 Phase 3–6 were filed without the `ready` label. To unblock them:
 
 ```bash
-cd ~/Documents/hangar
+cd ~/Documents/code/hangar
 for n in 5 11 12 13; do
   gh issue edit "$n" --add-label ready
 done
@@ -71,7 +98,7 @@ tmux send-keys -t hangar-build \
 
 ---
 
-## Stopping / resuming
+## Stopping / resuming the build
 
 ```bash
 # stop
@@ -109,7 +136,7 @@ Merge policy: **auto-merge if CI green**. The pipeline creates a branch and comm
 
 ```bash
 # From the builder agent's shell (pipeline provides this as the last step):
-cd ~/Documents/hangar
+cd ~/Documents/code/hangar
 gh pr create --fill --base main --head "$BRANCH"
 gh pr merge --auto --squash
 ```
@@ -120,29 +147,31 @@ The PR waits for CI to go green, then squash-merges. If CI fails, PR stays open 
 
 ## Watching the running product
 
-After Phase 2 ships:
-
-- Public dashboard: `https://optiplex.georgenijo.com/` (Phase 1 tunnel)
-- Tailnet dashboard: `http://optiplex:8080/`
+- Local dashboard: `http://localhost:8080/`
+- Public dashboard (when CF Tunnel is repointed): TBD — see [ADR-0017](decisions/0017-containerize-deployment.md)
 - Push notifications: subscribe on phone to the ntfy topic in `~/.config/hangar/config.toml`
-- Logs: `journalctl -u hangar -f`
-- Metrics: `curl http://optiplex:8080/api/v1/metrics`
+- Logs: `./scripts/deploy.sh container logs` (or `docker compose -f deploy/docker/compose.yml logs -f`)
+- Metrics: `curl http://localhost:8080/api/v1/metrics`
 
 ---
 
 ## Health checks
 
 ```bash
-systemctl status hangar hangar-supervisor caddy cloudflared-hangar
-ss -tlnp | grep -E ':(3000|8080)'
-du -sh ~/.local/state/hangar/
+docker compose -f deploy/docker/compose.yml ps
+docker compose -f deploy/docker/compose.yml exec hangar ps auxf
+docker volume inspect hangar-state
 ```
 
 ---
 
 ## Backup
 
-`restic` already runs on the box. Ensure it covers:
-- `~/.local/state/hangar/` (SQLite + ring files)
-- `~/.config/hangar/` (push rules, config)
-- `~/Documents/hangar/` (repo, if not relying on GitHub)
+The state volume is the only thing worth backing up:
+- `hangar-state` Docker volume (SQLite + ring files + supervisor socket)
+- `~/.config/hangar/` on the host if used (push rules, config)
+- The repo itself lives on GitHub
+
+Mac mini: include `~/Library/Containers/dev.kdrag0n.OrbStackHelper/Data/data/docker/volumes/hangar-state/` in Time Machine, or run `docker run --rm -v hangar-state:/data -v $PWD:/backup alpine tar czf /backup/hangar-state.tgz -C /data .` on a schedule.
+
+Cloud VM: include the Docker volume directory (`/var/lib/docker/volumes/hangar-state/`) in your provider's snapshot.

--- a/docs/decisions/0017-containerize-deployment.md
+++ b/docs/decisions/0017-containerize-deployment.md
@@ -1,0 +1,69 @@
+# ADR-0017: Containerize deployment, OrbStack on host
+
+**Status:** Accepted
+**Date:** 2026-05-12
+**Phase:** Cross-cutting (replaces optiplex/systemd host model from ADR-0006 / ADR-0010 era)
+
+## Context
+
+Hangar was originally designed around a single dedicated host (Dell OptiPlex 7050 running Ubuntu 24.04, ADR-0013) with systemd-managed services and a static install path. In practice the optiplex is underpowered for the workload and the user wants:
+
+1. **More compute** — multiple Claude/Codex sessions in parallel without thermal throttling. The new host is a Mac mini M4 / 24 GB.
+2. **Compartmentalization** — agents should not have unrestricted run of the host filesystem and processes.
+3. **Portability** — the same deployable should drop onto a cloud Linux VM (AWS EC2, Oracle Cloud free tier, Fly, Hetzner) without a port.
+
+A straight macOS native build is possible (gate sandbox module behind `cfg(target_os = "linux")`, write launchd plists — issues #88 and #89) but yields a mac-only artifact and abandons the existing Linux-only sandboxing design (Phase 6, podman + overlayfs). It also leaves the cloud VM story unresolved.
+
+## Options considered
+
+1. **Native macOS build, mac-only host** — close #88 and #89, run hangard under launchd directly on the mac. Trade-offs: simplest dev loop, but Phase 6 sandboxing has to be redesigned for macOS, no cloud portability without a second build target, agents share the host filesystem.
+
+2. **Linux container on the mac via OrbStack, same image on cloud VMs** — keep the Rust target Linux-only. Bind-mount host code and credentials into the container. Trade-offs: one more layer to learn, ~5–10 second container restart on the mac, but the existing Linux-only sandbox design survives, image is portable, agents are fenced from the host filesystem by container boundaries.
+
+3. **Full VM on the mac (UTM, multipass)** — Linux native inside the VM. Trade-offs: heavier than a container, no real upside over OrbStack for a single-app deployment.
+
+## Decision
+
+Hangar's canonical deployment artifact is a **multi-arch Linux container image** built from `deploy/docker/Dockerfile`. Locally it runs under OrbStack on `george-mac-mini` (arm64). For cloud VMs the same image runs under Docker or Podman (amd64 or arm64).
+
+The image bundles:
+- `hangard` (backend daemon)
+- `hangar-supervisor` (PTY supervisor)
+- frontend SPA (static files served by Caddy inside the container)
+- Caddy (reverse proxy on `:8080`)
+- `node` + `npm` runtime (so agent CLIs like `@anthropic-ai/claude-code` can be installed at runtime or layered in)
+
+The compose file (`deploy/docker/compose.yml`) defines:
+- Port `:8080` published to host
+- Named volume `hangar-state` mounted at `/state` — SQLite DB, ring buffers, supervisor socket survive image rebuilds
+- Bind mounts: host `~/Documents/code` → `/code` (sessions land here, agents edit your code in place), and a named volume `hangar-home` at `/home/hangar` for OAuth tokens, claude/codex config, project history.
+
+Native macOS build (#88 / #89) is **deprioritized**, not won't-fix. It can still be useful for a future "no container, just run a binary" mode, but it is not on the critical path.
+
+## Consequences
+
+- **Good:**
+  - One artifact targets local mac mini and any cloud Linux VM.
+  - Phase 6 sandboxing design (podman + overlayfs) survives — we're inside Linux semantics.
+  - Container boundary keeps agents from touching host files except where explicitly mounted.
+  - `docker compose up -d` is the install path everywhere; no host-specific service files.
+  - `~/.local/state/hangar` paths in the existing code map cleanly to a `/state` volume — backend already honors `HANGAR_STATE_DIR`.
+
+- **Bad:**
+  - Adds a runtime dependency on OrbStack (mac) or Docker (cloud). For a single-user tool this is acceptable.
+  - First boot includes a multi-minute Rust release build. Future work: cargo-chef layer caching.
+  - Cloudflare Tunnel needs to reach the published port — either run `cloudflared` on the mac host pointing at `:8080`, or add a sidecar `cloudflared` container.
+  - The "supervisor keeps PTYs alive while backend restarts" pattern (ADR-0010) only protects within-container restarts. If the whole container is killed, sessions reset.
+
+- **Future work opened up:**
+  - Multi-arch buildx pipeline (arm64 + amd64) for cloud VM deploys.
+  - Cargo-chef caching to drop subsequent build time to seconds.
+  - Decide whether Phase 6 nested-container sandboxing is still worth building or whether outer-container isolation is sufficient.
+  - `cloudflared` sidecar pattern for the public URL.
+  - Backup story replacement for the existing `restic` job on the optiplex (Time Machine on the mac, or a backup sidecar).
+
+## Supersedes / relates to
+
+- Updates the host assumption in ADR-0013 (tailnet-only auth) — the boundary now sits in front of the published container port, not in front of the optiplex.
+- Reopens the design space referenced in ADR-0006 (no sandboxing in MVP) and the Phase 6 phase doc.
+- Does **not** change ADR-0003 (Rust + axum + portable-pty), ADR-0004 (SQLite + ring buffer), or ADR-0010 (supervisor pattern) — they all work inside the container.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -54,3 +54,4 @@ What we chose.
 | 0014 | Dashboard visibility is the killer feature | Accepted |
 | 0015 | MVP bundles backend + UI + push + REST into one release | Accepted |
 | 0016 | Self-host ntfy behind Caddy | Accepted |
+| 0017 | Containerize deployment, OrbStack on host | Accepted |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,12 +1,60 @@
 #!/usr/bin/env bash
-# Usage: deploy.sh <backend|phase0|help>
+# Usage: deploy.sh <container|backend|phase0|help> [...]
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-echo "repo: $REPO"
+COMPOSE_FILE="$REPO/deploy/docker/compose.yml"
+PROJECT_NAME="hangar"
 
 case "${1:-}" in
+container)
+	sub="${2:-up}"
+	case "$sub" in
+	build)
+		echo "=== building container image ==="
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" build
+		;;
+	up)
+		echo "=== starting hangar ==="
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" up -d
+		echo
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" ps
+		echo
+		echo "dashboard: http://localhost:8080"
+		;;
+	down)
+		echo "=== stopping hangar ==="
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" down
+		;;
+	logs)
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" logs -f --tail=200
+		;;
+	restart)
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" restart
+		;;
+	status|ps)
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" ps
+		;;
+	shell)
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" exec hangar bash
+		;;
+	rebuild)
+		echo "=== rebuilding from scratch ==="
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" down
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" build --no-cache
+		docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" up -d
+		;;
+	*)
+		echo "Usage: deploy.sh container <build|up|down|logs|restart|status|shell|rebuild>" >&2
+		exit 1
+		;;
+	esac
+	;;
+
 backend)
+	# Legacy path: build natively and restart systemd services on a Linux host.
+	# Used for cloud-VM deployments that don't use the container image. See
+	# docs/decisions/0017-containerize-deployment.md for the canonical flow.
 	echo "=== pulling latest ==="
 	git -C "$REPO" pull
 
@@ -24,7 +72,6 @@ backend)
 
 	echo "--- status ---"
 	systemctl is-active hangar caddy
-	echo "dashboard: http://optiplex:8080"
 	;;
 
 phase0)
@@ -55,23 +102,32 @@ phase0)
 	echo "--- status ---"
 	systemctl is-active ttyd-codex ttyd-wave ttyd-issue12 caddy
 	ss -tlnp 2>/dev/null | grep -E ':(7682|7683|7684|8080)' || true
-
-	echo
-	echo "dashboard: http://optiplex:8080"
 	;;
 
-help)
-	echo "Usage: deploy.sh <subcommand>"
-	echo ""
-	echo "Subcommands:"
-	echo "  backend   git pull + cargo build + pnpm build + systemctl restart hangar"
-	echo "  phase0    Emergency rollback: install Phase 0 ttyd stopgap (requires service files restored from git history)"
-	echo "  help      Show this message"
-	exit 0
+help|"")
+	cat <<'EOF'
+Usage: deploy.sh <subcommand>
+
+Primary (local + cloud-VM with Docker):
+  container build        build the image
+  container up           start hangar (detached) and print status
+  container down         stop hangar
+  container logs         tail compose logs
+  container restart      restart services
+  container status       compose ps
+  container shell        bash into the hangar container
+  container rebuild      down + no-cache build + up
+
+Legacy (cloud-VM with systemd, not the canonical path):
+  backend                git pull + cargo build + pnpm build + systemctl restart
+
+Emergency:
+  phase0                 install Phase 0 ttyd stopgap (requires restored service files)
+EOF
 	;;
 
 *)
-	echo "Error: subcommand required" >&2
+	echo "Error: unknown subcommand '$1'" >&2
 	echo "Run 'deploy.sh help' for usage" >&2
 	exit 1
 	;;


### PR DESCRIPTION
## Summary
- Single Linux container image runs locally on Mac mini under OrbStack and identically on any cloud Linux VM.
- Adds `deploy/docker/` (Dockerfile, compose.yml, Caddyfile, entrypoint.sh), `.dockerignore`, and `scripts/deploy.sh container {build,up,down,logs}`.
- ADR-0017 captures the host migration off the retired optiplex; README/ARCHITECTURE/ROADMAP/RUNBOOK updated to container-first.

## Test plan
- [ ] `./scripts/deploy.sh container build` succeeds
- [ ] `./scripts/deploy.sh container up` starts container, `http://localhost:8080` loads dashboard
- [ ] Spawn a session via UI, confirm WebSocket live updates
- [ ] `docker volume inspect hangar-state` shows persisted SQLite + ring files after `down`/`up`
- [ ] Repoint Cloudflare Tunnel to Mac mini (separate task)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Hangar is now distributed as a Docker container image, enabling seamless deployment on Mac (via OrbStack) and cloud Linux VMs as a single artifact.

* **Documentation**
  * Updated README, Architecture, and Runbook documentation to reflect containerized deployment workflows and local/cloud setup instructions.

* **Chores**
  * Added containerized build and deployment configuration files; updated deployment scripts for container-based operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->