### PR TITLE
fix(keybind): replace dead ⌘N with g n two-key leader

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -45,7 +45,7 @@
 				return;
 			}
 
-			if (leaderPending && e.key === 'n' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+			if (leaderPending && e.key === 'n' && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
 				e.preventDefault();
 				leaderPending = false;
 				if (leaderTimer) { clearTimeout(leaderTimer); leaderTimer = null; }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -52,9 +52,13 @@
 				spawnOpen = true;
 				return;
 			}
-			if (e.key === 'g' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+			if (e.key === 'g' && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
+				if (leaderPending) {
+					leaderPending = false;
+					if (leaderTimer) { clearTimeout(leaderTimer); leaderTimer = null; }
+					return;
+				}
 				leaderPending = true;
-				if (leaderTimer) clearTimeout(leaderTimer);
 				leaderTimer = setTimeout(() => { leaderPending = false; }, 1500);
 				return;
 			}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -11,8 +11,6 @@
 
 	// hook test edit
 	let spawnOpen = $state(false);
-	let leaderPending = $state(false);
-	let leaderTimer: ReturnType<typeof setTimeout> | null = null;
 	let collapsed = $derived(sidebarStore.dashboardCollapsed);
 
 	$effect(() => {
@@ -29,9 +27,12 @@
 	});
 
 	$effect(() => {
+		let leaderPending = false;
+		let leaderTimer: ReturnType<typeof setTimeout> | null = null;
+
 		function onKey(e: KeyboardEvent) {
 			const tag = (e.target as HTMLElement).tagName;
-			if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable) return;
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || !!(e.target as HTMLElement).closest('[contenteditable]')) return;
 
 			if (e.ctrlKey && e.key === '\\') {
 				e.preventDefault();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -45,7 +45,7 @@
 				return;
 			}
 
-			if (leaderPending && e.key === 'n') {
+			if (leaderPending && e.key === 'n' && !e.ctrlKey && !e.metaKey && !e.altKey) {
 				e.preventDefault();
 				leaderPending = false;
 				if (leaderTimer) { clearTimeout(leaderTimer); leaderTimer = null; }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -11,6 +11,8 @@
 
 	// hook test edit
 	let spawnOpen = $state(false);
+	let leaderPending = $state(false);
+	let leaderTimer: ReturnType<typeof setTimeout> | null = null;
 	let collapsed = $derived(sidebarStore.dashboardCollapsed);
 
 	$effect(() => {
@@ -28,17 +30,43 @@
 
 	$effect(() => {
 		function onKey(e: KeyboardEvent) {
-			if (!e.ctrlKey || e.key !== '\\') return;
-			e.preventDefault();
-			const path = $page.url.pathname;
-			if (path.startsWith('/session/')) {
-				sidebarStore.toggleSession();
-			} else {
-				sidebarStore.toggleDashboard();
+			const tag = (e.target as HTMLElement).tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable) return;
+
+			if (e.ctrlKey && e.key === '\\') {
+				e.preventDefault();
+				const path = $page.url.pathname;
+				if (path.startsWith('/session/')) {
+					sidebarStore.toggleSession();
+				} else {
+					sidebarStore.toggleDashboard();
+				}
+				return;
+			}
+
+			if (leaderPending && e.key === 'n') {
+				e.preventDefault();
+				leaderPending = false;
+				if (leaderTimer) { clearTimeout(leaderTimer); leaderTimer = null; }
+				spawnOpen = true;
+				return;
+			}
+			if (e.key === 'g' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+				leaderPending = true;
+				if (leaderTimer) clearTimeout(leaderTimer);
+				leaderTimer = setTimeout(() => { leaderPending = false; }, 1500);
+				return;
+			}
+			if (leaderPending) {
+				leaderPending = false;
+				if (leaderTimer) { clearTimeout(leaderTimer); leaderTimer = null; }
 			}
 		}
 		document.addEventListener('keydown', onKey);
-		return () => document.removeEventListener('keydown', onKey);
+		return () => {
+			document.removeEventListener('keydown', onKey);
+			if (leaderTimer) clearTimeout(leaderTimer);
+		};
 	});
 
 	function handleCreated(_session: Session) {
@@ -76,7 +104,7 @@
 			<div class="topbar-left">
 				<span class="logo">Hangar</span>
 			</div>
-			<button class="btn-primary" onclick={() => (spawnOpen = true)}>＋ New Session</button>
+			<button class="btn-primary" onclick={() => (spawnOpen = true)} title="New session (g n)">＋ New Session</button>
 		</header>
 
 		<div class="page-content">


### PR DESCRIPTION
Closes #91.

## What changed

Replaces the dead `⌘N`/`Ctrl+N` shortcut (browser-intercepted) with a Vim-style `g n` two-key leader sequence to open SpawnModal. Adds `title="New session (g n)"` tooltip on the `+ New Session` button for discoverability.

**Implementation details:**
- `leaderPending` / `leaderTimer` live as plain `let` inside the `$effect` (not `$state`) — no reactivity leak, each closure owns its own references
- Guard skips handler when focus is in `INPUT`, `TEXTAREA`, or any `[contenteditable]` ancestor
- `g` arm guards against `Ctrl`/`Meta`/`Alt`/`Shift`
- `n` arm guards against `Ctrl`/`Meta`/`Alt`/`Shift`
- `g g` cancels the pending leader (no double-press re-arm)
- Timer auto-cancels leader after 1500 ms

## Repro / test plan

1. Open `http://localhost:8080/`
2. Ensure focus is NOT in any text input
3. Press `g`, then within 1.5 s press `n` → SpawnModal opens
4. Press `g g` → nothing (leader cancelled, no modal)
5. Press `g` then wait 1.5 s → nothing (timer expires)
6. Click inside any text input, press `g n` → no modal (guard fires)
7. `+ New Session` button tooltip shows "New session (g n)"
8. `⌘N` / `Ctrl+N` still opens a new browser tab (browser-level, unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `g n` keyboard shortcut sequence to quickly open the spawn modal
  * Refined `Ctrl+\` keyboard handling to toggle between session and dashboard sidebars
  * Enhanced keyboard input detection to prevent shortcuts from triggering while typing in input fields or editable areas
  * Updated button tooltip to reflect the new keyboard shortcuts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->