### PR TITLE
fix(ui): remove dead spawnOpen state from +page.svelte

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -5,11 +5,9 @@
 	import SearchPanel from '$lib/components/SearchPanel.svelte';
 	import type { SearchResult } from '$lib/types';
 
-	let spawnOpen = $state(false);
 	let searchOpen = $state(false);
 
 	function openSpawn() {
-		spawnOpen = true;
 		dispatchEvent(new CustomEvent('hangar:open-spawn'));
 	}
 


### PR DESCRIPTION
Closes #94.

## What changed

On `main`, `Topbar.svelte` was never merged (the topbar is inlined in `+layout.svelte` without a search input, so Option B from the issue was implicitly applied). However, `+page.svelte` carried the same class of inert-state bug: `spawnOpen` was declared as `$state` and set to `true` inside `openSpawn()`, but nothing in the file ever *read* it. The SpawnModal lives in `+layout.svelte` and is triggered exclusively via the `hangar:open-spawn` event. The local state had no effect.

Removes:
- `let spawnOpen = $state(false);`
- `spawnOpen = true;` inside `openSpawn()`

The `dispatchEvent(new CustomEvent('hangar:open-spawn'))` call is preserved — that's the actual mechanism.

## Repro / test plan

No visible behavioral change. Verify:
1. Empty-state "Create one" button still opens SpawnModal (fires `openSpawn` → event → layout opens modal)
2. TypeScript check passes: `pnpm --filter frontend check` → 0 errors/warnings
3. Build passes: `pnpm --filter frontend build` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal state management for the spawn creation flow, improving code organization and maintainability without impacting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->