### PR TITLE
fix(backend): populate sessions.agent_meta from driver events

### DIFF
--- a/backend/src/pty.rs
+++ b/backend/src/pty.rs
@@ -16,7 +16,7 @@ use crate::events::{AgentEvent, Event, EventBus};
 use crate::raw_fd_master::RawFdMaster;
 use crate::ringbuf::{RingBuf, DEFAULT_CAPACITY};
 use crate::sandbox::{SandboxState, SandboxStatus};
-use crate::session::{Session, SessionId, SessionState};
+use crate::session::{AgentMeta, Session, SessionId, SessionState};
 use crate::util;
 
 /// Reap a PTY child process to prevent it lingering as a zombie.
@@ -179,6 +179,8 @@ fn spawn_watchdog(
         let mut event_timestamps: VecDeque<i64> = VecDeque::new();
         let mut last_activity_ms: i64 = 0;
         let sid_str = session_id.to_string();
+        let mut agent_meta: Option<AgentMeta> = None;
+        let mut meta_dirty = false;
 
         loop {
             std::thread::sleep(Duration::from_secs(5));
@@ -187,19 +189,71 @@ fn spawn_watchdog(
             loop {
                 match event_rx.try_recv() {
                     Ok((sid, Event::AgentEvent { event, .. })) if sid == sid_str => {
-                        last_event = Some(event);
                         let ts = crate::util::now_ms() as i64;
                         event_timestamps.push_back(ts);
                         if event_timestamps.len() > 20 {
                             event_timestamps.pop_front();
                         }
                         last_activity_ms = ts;
+
+                        let meta = agent_meta.get_or_insert_with(|| AgentMeta {
+                            name: "claude_code".to_string(),
+                            version: None,
+                            model: None,
+                            tokens_used: 0,
+                            last_tool_call: None,
+                            context_pct: None,
+                            cost_dollars: None,
+                        });
+
+                        match &event {
+                            AgentEvent::ModelChanged { model } => {
+                                meta.model = Some(model.clone());
+                                meta_dirty = true;
+                            }
+                            AgentEvent::TurnFinished { tokens_used, .. } => {
+                                meta.tokens_used += *tokens_used as u64;
+                                meta_dirty = true;
+                            }
+                            AgentEvent::ToolCallStarted { tool, .. } => {
+                                meta.last_tool_call = Some(tool.clone());
+                                meta_dirty = true;
+                            }
+                            AgentEvent::ContextWindowSizeChanged { pct_used, .. } => {
+                                meta.context_pct = Some(*pct_used);
+                                meta_dirty = true;
+                            }
+                            AgentEvent::CostUpdated { dollars } => {
+                                meta.cost_dollars = Some(*dollars);
+                                meta_dirty = true;
+                            }
+                            _ => {}
+                        }
+
+                        last_event = Some(event);
                     }
                     Ok(_) => {}
                     Err(broadcast::error::TryRecvError::Empty) => break,
-                    Err(broadcast::error::TryRecvError::Lagged(_)) => break,
+                    Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            session_id = %sid_str,
+                            dropped = n,
+                            "watchdog lagged: agent_meta may be stale for dropped events",
+                        );
+                    }
                     Err(broadcast::error::TryRecvError::Closed) => return,
                 }
+            }
+
+            if meta_dirty {
+                if let Some(ref meta) = agent_meta {
+                    let _ = handle.block_on(Session::update_agent_meta(
+                        &db_pool,
+                        &session_id,
+                        meta,
+                    ));
+                }
+                meta_dirty = false;
             }
 
             let current = current_state.lock().unwrap().clone();

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -97,6 +97,10 @@ pub struct AgentMeta {
     pub model: Option<String>,
     pub tokens_used: u64,
     pub last_tool_call: Option<String>,
+    #[serde(default)]
+    pub context_pct: Option<f32>,
+    #[serde(default)]
+    pub cost_dollars: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -223,6 +227,27 @@ impl Session {
             .execute(pool)
             .await?;
 
+        Ok(())
+    }
+
+    pub async fn update_agent_meta(
+        pool: &SqlitePool,
+        id: &SessionId,
+        meta: &AgentMeta,
+    ) -> Result<()> {
+        let id_str = id.to_string();
+        let meta_json = serde_json::to_string(meta)?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_millis() as i64;
+        sqlx::query(
+            "UPDATE sessions SET agent_meta = ?, last_activity_at = ? WHERE id = ?",
+        )
+        .bind(&meta_json)
+        .bind(now)
+        .bind(&id_str)
+        .execute(pool)
+        .await?;
         Ok(())
     }
 
@@ -404,6 +429,8 @@ impl Session {
                         model: Some(legacy.model),
                         tokens_used: legacy.prompt_tokens + legacy.completion_tokens,
                         last_tool_call: None,
+                        context_pct: None,
+                        cost_dollars: None,
                     })
                 })
             })
@@ -453,4 +480,80 @@ struct SessionRow {
     last_activity_at: i64,
     exit: Option<String>,
     sandbox: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_meta_new_fields_default_null_on_legacy() {
+        let json = r#"{"name":"claude_code","tokens_used":100}"#;
+        let meta: AgentMeta = serde_json::from_str(json).unwrap();
+        assert!(meta.context_pct.is_none());
+        assert!(meta.cost_dollars.is_none());
+    }
+
+    #[test]
+    fn test_agent_meta_round_trips_new_fields() {
+        let meta = AgentMeta {
+            name: "claude_code".to_string(),
+            version: None,
+            model: Some("claude-sonnet-4".to_string()),
+            tokens_used: 1234,
+            last_tool_call: Some("Bash".to_string()),
+            context_pct: Some(0.42),
+            cost_dollars: Some(0.015),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: AgentMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.tokens_used, 1234);
+        assert!((back.context_pct.unwrap() - 0.42).abs() < 1e-4);
+        assert!((back.cost_dollars.unwrap() - 0.015).abs() < 1e-6);
+        assert_eq!(back.last_tool_call.as_deref(), Some("Bash"));
+    }
+
+    #[tokio::test]
+    async fn test_update_agent_meta_persists() {
+        let db = crate::db::Db::new_in_memory().await.unwrap();
+        let pool = db.pool();
+
+        let s = Session {
+            id: SessionId::new(),
+            slug: "test-slug".to_string(),
+            node_id: "local".to_string(),
+            kind: SessionKind::ClaudeCode {
+                config_override: None,
+                project_dir: None,
+            },
+            state: SessionState::Idle,
+            cwd: "/tmp".to_string(),
+            env: serde_json::json!({}),
+            agent_meta: None,
+            labels: serde_json::json!([]),
+            created_at: 0,
+            last_activity_at: 0,
+            exit: None,
+            sandbox: None,
+        };
+        s.insert(pool).await.unwrap();
+
+        let meta = AgentMeta {
+            name: "claude_code".to_string(),
+            version: None,
+            model: Some("claude-sonnet-4".to_string()),
+            tokens_used: 999,
+            last_tool_call: Some("Bash".to_string()),
+            context_pct: Some(0.5),
+            cost_dollars: Some(0.02),
+        };
+        Session::update_agent_meta(pool, &s.id, &meta).await.unwrap();
+
+        let loaded = Session::get(pool, &s.id).await.unwrap().unwrap();
+        let m = loaded.agent_meta.unwrap();
+        assert_eq!(m.model.as_deref(), Some("claude-sonnet-4"));
+        assert_eq!(m.tokens_used, 999);
+        assert!((m.context_pct.unwrap() - 0.5).abs() < 1e-4);
+        assert!((m.cost_dollars.unwrap() - 0.02).abs() < 1e-6);
+    }
 }


### PR DESCRIPTION
## Summary
- `AgentMeta` gets two new optional fields: `context_pct` and `cost_dollars`
- New `Session::update_agent_meta()` writes meta JSON to the DB
- Watchdog in `pty.rs` now accumulates model/tokens/tool/ctx/cost from events and persists on each 5-second tick
- Lagged broadcast receiver now logs a warning instead of silently breaking

## Test plan
- [x] `cargo test --lib` — 68 passed, 2 ignored
- [x] `session::tests::test_update_agent_meta_persists` — DB round-trip verified
- [x] `session::tests::test_agent_meta_round_trips_new_fields` — serde verified
- [x] `session::tests::test_agent_meta_new_fields_default_null_on_legacy` — backwards compat verified

Fixes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent sessions now track cost metrics (in dollars) and context window usage percentage
  * Agent metadata is periodically persisted and updated in the database

* **Improvements**
  * Enhanced session monitoring resilience; system gracefully handles and logs connectivity issues instead of immediately shutting down

<!-- end of auto-generated comment: release notes by coderabbit.ai -->