### PR TITLE
fix(state): sticky streaming + faster poll for booting/awaiting

### DIFF
--- a/backend/src/drivers/claude_code.rs
+++ b/backend/src/drivers/claude_code.rs
@@ -494,7 +494,10 @@ impl AgentDriver for ClaudeCodeDriver {
         }
 
         if let Some(AgentEvent::TurnFinished { .. }) = &ctx.last_event {
-            if ctx.current_state != SessionState::Idle {
+            // Sticky streaming: hold Streaming state for 3s after last byte so
+            // rapid turn boundaries don't flicker idle.
+            let quiet_ms = util::now_ms() as i64 - ctx.last_bytes_ms;
+            if quiet_ms > 3_000 && ctx.current_state != SessionState::Idle {
                 return Some(SessionState::Idle);
             }
         }
@@ -679,6 +682,7 @@ mod tests {
     #[test]
     fn test_detect_state_idle_after_turn_finished() {
         let d = ClaudeCodeDriver::new();
+        let stale_ms = util::now_ms() as i64 - 5_000;
         let ctx = StateCtx {
             current_state: SessionState::Streaming,
             last_activity_ms: 0,
@@ -687,7 +691,7 @@ mod tests {
                 tokens_used: 0,
                 duration_ms: 0,
             }),
-            last_bytes_ms: 0,
+            last_bytes_ms: stale_ms,
             event_timestamps: vec![],
         };
         assert_eq!(d.detect_state(&ctx), Some(SessionState::Idle));
@@ -722,5 +726,42 @@ mod tests {
             event_timestamps: vec![],
         };
         assert_eq!(d.detect_state(&ctx), None);
+    }
+
+    #[test]
+    fn test_detect_state_sticky_streaming_holds_when_bytes_recent() {
+        let d = ClaudeCodeDriver::new();
+        let recent_ms = util::now_ms() as i64 - 500; // 500ms ago — within sticky window
+        let ctx = StateCtx {
+            current_state: SessionState::Streaming,
+            last_activity_ms: 0,
+            last_event: Some(AgentEvent::TurnFinished {
+                turn_id: 1,
+                tokens_used: 0,
+                duration_ms: 0,
+            }),
+            last_bytes_ms: recent_ms,
+            event_timestamps: vec![],
+        };
+        // Should NOT transition to Idle — bytes too recent
+        assert_eq!(d.detect_state(&ctx), None);
+    }
+
+    #[test]
+    fn test_detect_state_idle_after_turn_finished_bytes_stale() {
+        let d = ClaudeCodeDriver::new();
+        let stale_ms = util::now_ms() as i64 - 5_000; // 5s ago — beyond sticky window
+        let ctx = StateCtx {
+            current_state: SessionState::Streaming,
+            last_activity_ms: 0,
+            last_event: Some(AgentEvent::TurnFinished {
+                turn_id: 1,
+                tokens_used: 0,
+                duration_ms: 0,
+            }),
+            last_bytes_ms: stale_ms,
+            event_timestamps: vec![],
+        };
+        assert_eq!(d.detect_state(&ctx), Some(SessionState::Idle));
     }
 }

--- a/backend/src/drivers/codex.rs
+++ b/backend/src/drivers/codex.rs
@@ -155,7 +155,8 @@ impl AgentDriver for CodexDriver {
         }
 
         if let Some(AgentEvent::TurnFinished { .. }) = &ctx.last_event {
-            if ctx.current_state != SessionState::Idle {
+            let quiet_ms = util::now_ms() as i64 - ctx.last_bytes_ms;
+            if quiet_ms > 3_000 && ctx.current_state != SessionState::Idle {
                 return Some(SessionState::Idle);
             }
         }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -52,6 +52,9 @@ export const sessionsStore = {
 		});
 		return filterByLabels(sorted, selectedLabels);
 	},
+	get hasActiveSessions() {
+		return sessions.some((s) => ['streaming', 'awaiting', 'booting'].includes(s.state));
+	},
 	get hasStreamingSessions() {
 		return sessions.some((s) => s.state === 'streaming');
 	},
@@ -99,8 +102,9 @@ export const sessionsStore = {
 
 			if (intervalId !== null) {
 				clearInterval(intervalId);
+				const isActive = sessions.some((s) => ['streaming', 'awaiting', 'booting'].includes(s.state));
 				const pollMs =
-					consecutiveFailures >= 3 ? 10000 : sessions.some((s) => s.state === 'streaming') ? 500 : 3000;
+					consecutiveFailures >= 3 ? 10000 : isActive ? 500 : 3000;
 				intervalId = setInterval(tick, pollMs);
 			}
 		};


### PR DESCRIPTION
## Summary
- Backend: `detect_state()` now requires 3s of byte silence before `TurnFinished` transitions to Idle — prevents state flicker on banner output
- Frontend: fast polling (500ms) now triggers for `streaming | awaiting | booting`, not just `streaming`
- Tests: updated pre-existing `test_detect_state_idle_after_turn_finished` to use real stale timestamp; added 2 new sticky-streaming tests

## Test plan
- [x] `cargo test --lib` — 70 passed, 2 ignored
- [x] `pnpm --filter frontend check` — 0 errors, 0 warnings
- [x] `pnpm --filter frontend build` — success

Fixes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session idle detection with a 3-second quiet threshold, preventing premature disconnections during streaming operations.

* **New Features**
  * Enhanced polling logic to better identify active sessions and adjust refresh rates accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->