### PR TITLE
fix(scraper): debug log on emit + tests for latest-match cost

### DIFF
--- a/backend/src/drivers/mod.rs
+++ b/backend/src/drivers/mod.rs
@@ -68,6 +68,15 @@ pub mod status_scraper {
                 None => true,
             };
             if values_changed || heartbeat_due {
+                tracing::debug!(
+                    pct,
+                    tokens_k,
+                    dollars,
+                    prev_dollars = ?state.last_dollars,
+                    values_changed,
+                    heartbeat_due,
+                    "scraper: emitting status update",
+                );
                 state.last_dollars = Some(dollars);
                 state.last_pct = Some(pct);
                 state.last_tokens_k = Some(tokens_k);
@@ -176,6 +185,24 @@ pub mod status_scraper {
             // tokens_k changes (32 vs 30), pct stays 3%
             let evs = scrape_status("CTX 3% 32k $0.11 | foo | claude-opus-4-7 |", &mut state);
             assert!(evs.len() >= 2);
+        }
+
+        #[test]
+        fn scrape_status_latest_match_wins_when_buffer_has_multiple() {
+            // Two status lines in same buffer — scraper must take the later (higher) cost.
+            let mut state = ScraperState::default();
+            let chunk = "CTX 4% 40k $0.21 | foo | claude-opus-4-7 | CTX 4% 40k $0.27 | foo | claude-opus-4-7 |";
+            let evs = scrape_status(chunk, &mut state);
+            assert!(evs.iter().any(|e| matches!(e, AgentEvent::CostUpdated { dollars } if (*dollars - 0.27).abs() < 1e-6)));
+        }
+
+        #[test]
+        fn scrape_status_emits_cost_update_when_only_cost_changes() {
+            let mut state = ScraperState::default();
+            scrape_status("CTX 4% 40k $0.21 | foo | claude-opus-4-7 |", &mut state);
+            // Same pct and tokens, only cost changed.
+            let evs = scrape_status("CTX 4% 40k $0.27 | foo | claude-opus-4-7 |", &mut state);
+            assert!(evs.iter().any(|e| matches!(e, AgentEvent::CostUpdated { dollars } if (*dollars - 0.27).abs() < 1e-6)));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `tracing::debug!` in the status scraper when CTX/cost values are emitted, enabling future cost-lag diagnosis
- Adds test `scrape_status_latest_match_wins_when_buffer_has_multiple`: verifies `.last()` picks up the higher/newer cost when two status lines coexist in buffer
- Adds test `scrape_status_emits_cost_update_when_only_cost_changes`: confirms cost-only changes (stable pct + tokens) trigger a `CostUpdated` event

Note: `Session{id:` artifact was already fixed in #73. Scraper already used `.last()`. This closes the remaining items.

## Test plan
- [x] `cargo test --lib` — 72 passed, 2 ignored

Fixes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the status scraper with two additional cases: verifying correct handling of multiple status updates and ensuring cost-only changes trigger appropriate events.

* **Chores**
  * Improved observability by adding debug logging for status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->