### PR TITLE
fix(pipeline): require scenarios + summary for PASS gate

### DIFF
--- a/.pipeline/agents/tester.md
+++ b/.pipeline/agents/tester.md
@@ -33,6 +33,14 @@ Write your results to the file path specified in the prompt.
 ```json
 {
   "status": "PASS" | "FAIL",
+  "summary": "One sentence describing what was verified and the outcome.",
+  "scenarios": [
+    {
+      "name": "issue-<N>: <short description of the specific bug/feature repro>",
+      "status": "pass" | "fail",
+      "details": "step-by-step of what was done and observed"
+    }
+  ],
   "tests": [
     {
       "name": "descriptive test name",
@@ -54,3 +62,5 @@ Write your results to the file path specified in the prompt.
 - Take screenshots of failures
 - Always close the browser when done
 - CRITICAL: Write your results to the file path given in the prompt
+- CRITICAL: `scenarios` must contain at least one entry named with the issue ID (e.g. `"issue-60: cost sidebar shows live value"`). Generic dashboard sweeps are not enough — reproduce the specific bug from the issue.
+- CRITICAL: `summary` must be a non-empty sentence. A PASS with empty summary or empty scenarios will be rejected by the pipeline gate.

--- a/.pipeline/pipeline.sh
+++ b/.pipeline/pipeline.sh
@@ -386,6 +386,31 @@ Write test results to: $TEST_RESULTS" "$FIX_ROUND"
         fi
       fi
 
+      # Scenario gate: must have >=1 scenario with the issue ID referenced
+      SCENARIO_COUNT=$(jq '(.scenarios // []) | length' "$TEST_RESULTS" 2>/dev/null || echo 0)
+      if [ "$SCENARIO_COUNT" -lt 1 ]; then
+        echo "    [pipeline] tester produced $SCENARIO_COUNT scenarios — PASS requires >=1 bug-specific scenario"
+        GATE_PASS=false
+        GATE_NOTES="${GATE_NOTES}requires >=1 scenario in scenarios[], got $SCENARIO_COUNT; "
+      else
+        ISSUE_REF_FOUND=$(jq --arg id "$ISSUE_NUM" \
+          '[.scenarios[]? | .name // . | ascii_downcase | test("(#|issue-)" + $id)] | any' \
+          "$TEST_RESULTS" 2>/dev/null || echo "false")
+        if [ "$ISSUE_REF_FOUND" != "true" ]; then
+          echo "    [pipeline] no scenario references issue #$ISSUE_NUM — rejecting PASS"
+          GATE_PASS=false
+          GATE_NOTES="${GATE_NOTES}at least one scenario name must reference issue #$ISSUE_NUM or issue-$ISSUE_NUM; "
+        fi
+      fi
+
+      # Summary gate: must be non-empty
+      SUMMARY=$(jq -r '.summary // ""' "$TEST_RESULTS" 2>/dev/null || echo "")
+      if [ -z "$SUMMARY" ]; then
+        echo "    [pipeline] summary is empty — rejecting PASS"
+        GATE_PASS=false
+        GATE_NOTES="${GATE_NOTES}summary field must be non-empty; "
+      fi
+
       if [ "$GATE_PASS" = true ]; then
         TESTS_PASS=true
         log_test_result "$FIX_ROUND" true


### PR DESCRIPTION
## Summary
- `pipeline.sh`: adds three new PASS gates after the screenshot check:
  1. `scenarios.length >= 1` — at least one bug-specific scenario required
  2. At least one scenario name must reference the issue ID (`#N` or `issue-N`)
  3. `summary` must be non-empty
- `tester.md`: adds `scenarios[]` and `summary` to the output schema, with a CRITICAL note explaining the gate requirements

## Test plan
- [x] Shell gate logic manually verified with 8 test cases (empty scenarios, missing key, no issue ref, empty summary, valid hash ref, valid issue-N ref, multi-scenario with partial ref)

Fixes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test result validation requirements to enforce mandatory summary field and structured scenario reporting format across all test outputs.
  * Enhanced quality gates with stricter validation rules for UI-surface changes, requiring test scenarios to explicitly reference issue identifiers for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->