### PR TITLE
fix(logs): document [logs] config + add startup hints

### DIFF
--- a/backend/src/logs/mod.rs
+++ b/backend/src/logs/mod.rs
@@ -44,7 +44,15 @@ impl LogsHub {
 
     pub fn start(&mut self) {
         if !self.enabled {
+            tracing::info!(
+                "logs firehose disabled — set [logs] enabled = true in config.toml to activate"
+            );
             return;
+        }
+        if self.sources.is_empty() {
+            tracing::warn!(
+                "logs firehose enabled but no sources configured — add [[logs.sources]] entries in config.toml"
+            );
         }
         for source in &self.sources {
             let tx = self.tx.clone();

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -155,6 +155,58 @@ The PR waits for CI to go green, then squash-merges. If CI fails, PR stays open 
 
 ---
 
+## Configuring the /logs firehose
+
+The `/logs` dashboard page tails live log sources declared in
+`~/.config/hangar/config.toml` (macOS: `~/Library/Application Support/hangar/config.toml`).
+
+### Enable and declare sources
+
+```toml
+[logs]
+enabled = true
+tail_lines = 500      # lines replayed on initial page load
+
+# macOS unified log stream (all sources)
+[[logs.sources]]
+name = "system"
+kind = "journalctl"
+
+# Single systemd/launchd unit (Linux: journalctl -u <unit>)
+[[logs.sources]]
+name = "caddy"
+kind = "unit"
+path = "caddy.service"
+
+# Arbitrary log file (absolute path, tailed like `tail -f`)
+[[logs.sources]]
+name = "hangard"
+kind = "file"
+path = "/var/log/hangar/hangard.log"
+
+# PTY scrollback from a running session
+[[logs.sources]]
+name = "claude-session"
+kind = "pane_scrollback"
+session_id = "<session-ulid>"
+```
+
+### Source types
+
+| kind | description | required field |
+|------|-------------|----------------|
+| `journalctl` | `journalctl -f` (all units) | — |
+| `unit` | single systemd unit | `path = "unit.service"` |
+| `file` | tails a log file | `path = "/abs/path.log"` |
+| `pane_scrollback` | session PTY ring buffer | `session_id = "<ulid>"` |
+
+### Filtering
+
+Click source name chips at the top of `/logs` to show/hide individual sources.
+The search box accepts regular expressions applied across visible lines.
+
+---
+
 ## Health checks
 
 ```bash


### PR DESCRIPTION
## Summary
- `docs/RUNBOOK.md`: adds full `[logs]` section with TOML examples for all four source types and a filter reference
- `backend/src/logs/mod.rs`: `LogsHub::start()` logs an info message when disabled and a warning when enabled with no sources

The backend tailers (file, journalctl, unit, pane_scrollback) and frontend (LogFilterChips, logsStore, LogsView, WebSocket) were already fully implemented. The only gap was configuration documentation.

## Test plan
- [x] `cargo test --lib` — 72 passed, 2 ignored

Fixes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive runbook section on configuring the `/logs` dashboard to tail live log sources.
  * Explained setup for multiple source types: system journals, units, files, and terminal pane history.
  * Documented UI filtering capabilities and regex search functionality over visible logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->