### PR TITLE
feat(backend): add /api/v1/costs/daily and /api/v1/costs/by-model

### DIFF
--- a/backend/src/api/costs.rs
+++ b/backend/src/api/costs.rs
@@ -1,0 +1,104 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::Serialize;
+use tracing::error;
+
+use crate::AppState;
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct DailyRow {
+    pub date: String,
+    pub usd: f64,
+    pub tokens: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DailyResponse {
+    pub days: Vec<DailyRow>,
+}
+
+pub async fn costs_daily(
+    State(state): State<AppState>,
+) -> Result<Json<DailyResponse>, StatusCode> {
+    let rows = sqlx::query_as::<_, DailyRow>(
+        r#"
+        SELECT
+            strftime('%Y-%m-%d', created_at / 1000, 'unixepoch') AS date,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.cost_dollars') AS REAL)), 0.0) AS usd,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.tokens_used') AS INTEGER)), 0) AS tokens
+        FROM sessions
+        WHERE agent_meta IS NOT NULL
+        GROUP BY date
+        ORDER BY date DESC
+        "#,
+    )
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(|e| {
+        error!("costs_daily query failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(DailyResponse { days: rows }))
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct ModelRow {
+    model: String,
+    usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ModelEntry {
+    pub model: String,
+    pub usd: f64,
+    pub share: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ByModelResponse {
+    pub models: Vec<ModelEntry>,
+}
+
+pub async fn costs_by_model(
+    State(state): State<AppState>,
+) -> Result<Json<ByModelResponse>, StatusCode> {
+    let rows = sqlx::query_as::<_, ModelRow>(
+        r#"
+        SELECT
+            json_extract(agent_meta, '$.model') AS model,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.cost_dollars') AS REAL)), 0.0) AS usd
+        FROM sessions
+        WHERE agent_meta IS NOT NULL
+          AND json_extract(agent_meta, '$.model') IS NOT NULL
+          AND json_extract(agent_meta, '$.model') != 'null'
+        GROUP BY model
+        ORDER BY usd DESC
+        "#,
+    )
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(|e| {
+        error!("costs_by_model query failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let total: f64 = rows.iter().map(|r| r.usd).sum();
+
+    let models = rows
+        .into_iter()
+        .map(|r| {
+            let share = if total > 0.0 {
+                (r.usd / total * 100.0).min(100.0)
+            } else {
+                0.0
+            };
+            ModelEntry {
+                model: r.model,
+                usd: r.usd,
+                share,
+            }
+        })
+        .collect();
+
+    Ok(Json(ByModelResponse { models }))
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod broadcast;
+pub mod costs;
 pub mod events;
 pub mod key;
 pub mod logs;
@@ -78,6 +79,8 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/search", get(search::search))
         .route("/api/v1/broadcast", post(broadcast::broadcast))
         .route("/api/v1/metrics", get(metrics::get_metrics))
+        .route("/api/v1/costs/daily", get(costs::costs_daily))
+        .route("/api/v1/costs/by-model", get(costs::costs_by_model))
         .route("/api/v1/logs/sources", get(logs::list_sources))
         .route("/ws/v1/sessions/:id/pty", get(crate::ws::pty::ws_pty))
         .route("/ws/v1/logs", get(crate::ws::logs::ws_handler))

--- a/backend/src/bin/fd_passing_spike.rs
+++ b/backend/src/bin/fd_passing_spike.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         unsafe {
             cmd.pre_exec(move || {
                 libc::setsid();
-                libc::ioctl(slave_raw, libc::TIOCSCTTY, 0i32);
+                libc::ioctl(slave_raw, libc::TIOCSCTTY.into(), 0i32);
                 libc::dup2(slave_raw, 0);
                 libc::dup2(slave_raw, 1);
                 libc::dup2(slave_raw, 2);

--- a/backend/src/bin/hangar-supervisor.rs
+++ b/backend/src/bin/hangar-supervisor.rs
@@ -319,7 +319,7 @@ fn do_spawn(
     unsafe {
         cmd.pre_exec(move || {
             libc::setsid();
-            libc::ioctl(slave_raw, libc::TIOCSCTTY, 0i32);
+            libc::ioctl(slave_raw, libc::TIOCSCTTY.into(), 0i32);
             libc::dup2(slave_raw, 0);
             libc::dup2(slave_raw, 1);
             libc::dup2(slave_raw, 2);

--- a/backend/tests/api_costs.rs
+++ b/backend/tests/api_costs.rs
@@ -1,0 +1,176 @@
+use hangard::{
+    db::Db,
+    session::{AgentMeta, Session, SessionId, SessionKind, SessionState},
+};
+
+fn make_session_with_meta(
+    pool: &sqlx::SqlitePool,
+    meta: AgentMeta,
+) -> impl std::future::Future<Output = Session> + '_ {
+    async move {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        let s = Session {
+            id: SessionId::new(),
+            slug: format!("cost-test-{}", SessionId::new()),
+            node_id: "local".to_string(),
+            kind: SessionKind::ClaudeCode {
+                config_override: None,
+                project_dir: None,
+            },
+            state: SessionState::Exited,
+            cwd: "/tmp".to_string(),
+            env: serde_json::json!({}),
+            agent_meta: None,
+            labels: serde_json::json!([]),
+            created_at: now,
+            last_activity_at: now,
+            exit: None,
+            sandbox: None,
+        };
+        s.insert(pool).await.unwrap();
+        Session::update_agent_meta(pool, &s.id, &meta).await.unwrap();
+        s
+    }
+}
+
+fn make_meta(model: &str, cost: f64, tokens: u64) -> AgentMeta {
+    AgentMeta {
+        name: "claude_code".to_string(),
+        version: None,
+        model: Some(model.to_string()),
+        tokens_used: tokens,
+        last_tool_call: None,
+        context_pct: None,
+        cost_dollars: Some(cost),
+    }
+}
+
+#[tokio::test]
+async fn costs_daily_empty_returns_empty_array() {
+    let db = Db::new_in_memory().await.unwrap();
+    let pool = db.pool();
+
+    let rows = sqlx::query_as::<_, (String, f64, i64)>(
+        r#"
+        SELECT
+            strftime('%Y-%m-%d', created_at / 1000, 'unixepoch') AS date,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.cost_dollars') AS REAL)), 0.0) AS usd,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.tokens_used') AS INTEGER)), 0) AS tokens
+        FROM sessions
+        WHERE agent_meta IS NOT NULL
+        GROUP BY date
+        ORDER BY date DESC
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap();
+
+    assert!(rows.is_empty(), "empty DB should yield no rows");
+}
+
+#[tokio::test]
+async fn costs_daily_sums_sessions_by_day() {
+    let db = Db::new_in_memory().await.unwrap();
+    let pool = db.pool();
+
+    make_session_with_meta(pool, make_meta("claude-sonnet-4", 0.10, 1000)).await;
+    make_session_with_meta(pool, make_meta("claude-opus-4", 0.20, 2000)).await;
+
+    let rows = sqlx::query_as::<_, (String, f64, i64)>(
+        r#"
+        SELECT
+            strftime('%Y-%m-%d', created_at / 1000, 'unixepoch') AS date,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.cost_dollars') AS REAL)), 0.0) AS usd,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.tokens_used') AS INTEGER)), 0) AS tokens
+        FROM sessions
+        WHERE agent_meta IS NOT NULL
+        GROUP BY date
+        ORDER BY date DESC
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap();
+
+    assert_eq!(rows.len(), 1, "both sessions on same day → 1 row");
+    let (_, usd, tokens) = &rows[0];
+    assert!((usd - 0.30).abs() < 1e-6, "total usd = 0.30, got {usd}");
+    assert_eq!(*tokens, 3000, "total tokens = 3000");
+}
+
+#[tokio::test]
+async fn costs_by_model_computes_share() {
+    let db = Db::new_in_memory().await.unwrap();
+    let pool = db.pool();
+
+    make_session_with_meta(pool, make_meta("claude-sonnet-4", 0.10, 1000)).await;
+    make_session_with_meta(pool, make_meta("claude-opus-4", 0.30, 2000)).await;
+
+    let rows = sqlx::query_as::<_, (String, f64)>(
+        r#"
+        SELECT
+            json_extract(agent_meta, '$.model') AS model,
+            COALESCE(SUM(CAST(json_extract(agent_meta, '$.cost_dollars') AS REAL)), 0.0) AS usd
+        FROM sessions
+        WHERE agent_meta IS NOT NULL
+          AND json_extract(agent_meta, '$.model') IS NOT NULL
+          AND json_extract(agent_meta, '$.model') != 'null'
+        GROUP BY model
+        ORDER BY usd DESC
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    let total: f64 = rows.iter().map(|r| r.1).sum();
+    assert!((total - 0.40).abs() < 1e-6, "total = 0.40");
+
+    let (model, usd) = &rows[0];
+    assert_eq!(model, "claude-opus-4");
+    let share = usd / total * 100.0;
+    assert!((share - 75.0).abs() < 0.01, "opus share = 75%, got {share}");
+}
+
+#[tokio::test]
+async fn costs_by_model_excludes_sessions_without_model() {
+    let db = Db::new_in_memory().await.unwrap();
+    let pool = db.pool();
+
+    // Session with no model in agent_meta
+    let meta_no_model = AgentMeta {
+        name: "claude_code".to_string(),
+        version: None,
+        model: None,
+        tokens_used: 500,
+        last_tool_call: None,
+        context_pct: None,
+        cost_dollars: Some(0.05),
+    };
+    make_session_with_meta(pool, meta_no_model).await;
+    make_session_with_meta(pool, make_meta("claude-sonnet-4", 0.10, 1000)).await;
+
+    let rows = sqlx::query_as::<_, (String, f64)>(
+        r#"
+        SELECT json_extract(agent_meta, '$.model') AS model,
+               COALESCE(SUM(CAST(json_extract(agent_meta, '$.cost_dollars') AS REAL)), 0.0) AS usd
+        FROM sessions
+        WHERE agent_meta IS NOT NULL
+          AND json_extract(agent_meta, '$.model') IS NOT NULL
+          AND json_extract(agent_meta, '$.model') != 'null'
+        GROUP BY model
+        ORDER BY usd DESC
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap();
+
+    assert_eq!(rows.len(), 1, "only session with model should appear");
+    assert_eq!(rows[0].0, "claude-sonnet-4");
+}


### PR DESCRIPTION
## Summary
- `GET /api/v1/costs/daily` → `{days:[{date,usd,tokens}]}` grouped by session creation date
- `GET /api/v1/costs/by-model` → `{models:[{model,usd,share}]}` from `sessions.agent_meta`
- Empty DB returns empty arrays (not 500)
- DB errors logged via `tracing::error!`
- `share` clamped to 100.0 to guard f64 drift
- Also fixes pre-existing macOS `TIOCSCTTY` ioctl type mismatch in two supervisor binaries

## Test plan
- [x] `cargo test --lib` — 72 passed, 2 ignored
- [x] `cargo test --test api_costs` — 4 passed (empty result, daily sum, share computation, null-model exclusion)

Fixes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to retrieve daily cost summaries, aggregating costs and token usage by session creation date
  * Added API endpoint to view costs grouped by model, displaying each model's total cost and percentage share of overall spending

* **Tests**
  * Added comprehensive test coverage for cost aggregation functionality, including edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->