### PR TITLE
feat(ui): CommandView + FleetView (Phase 4)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,7 +9,10 @@ import type {
 	SearchResult,
 	WorktreeTreeResponse,
 	WorktreeFileResponse,
-	WorktreeDiffResponse
+	WorktreeDiffResponse,
+	HostMetrics,
+	DailyCostsResponse,
+	PipelineRunsResponse
 } from './types';
 
 export class ApiError extends Error {
@@ -199,4 +202,19 @@ export function kindIcon(k: SessionKind): string {
 		case 'codex':
 			return 'bot';
 	}
+}
+
+export async function getHostMetrics(): Promise<HostMetrics> {
+	const res = await checkOk(await fetch('/api/v1/metrics/host'));
+	return res.json();
+}
+
+export async function getDailyCosts(): Promise<DailyCostsResponse> {
+	const res = await checkOk(await fetch('/api/v1/costs/daily'));
+	return res.json();
+}
+
+export async function getPipelineRuns(): Promise<PipelineRunsResponse> {
+	const res = await checkOk(await fetch('/api/v1/pipeline/runs'));
+	return res.json();
 }

--- a/frontend/src/lib/components/HostCard.svelte
+++ b/frontend/src/lib/components/HostCard.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import type { HostMetrics } from '$lib/types';
+	import RingGauge from './RingGauge.svelte';
+
+	let {
+		metrics,
+		sessionsCount,
+		loading,
+		error,
+		onRetry
+	}: {
+		metrics: HostMetrics | null;
+		sessionsCount: number;
+		loading: boolean;
+		error: string | null;
+		onRetry?: () => void;
+	} = $props();
+
+	function safeGb(total: number, pct: number, decimals: number): string {
+		const v = (total * pct) / 100;
+		return Number.isFinite(v) ? v.toFixed(decimals) : '—';
+	}
+
+	let ramUsed = $derived(metrics ? safeGb(metrics.ram_total_gb, metrics.ram_pct, 1) : '—');
+	let diskUsed = $derived(metrics ? safeGb(metrics.disk_total_gb, metrics.disk_pct, 0) : '—');
+</script>
+
+<div class="host-card">
+	<div class="card-header">
+		<h2 class="hostname">{metrics?.hostname ?? (loading ? '…' : '—')}</h2>
+		<span class="sessions-badge">{sessionsCount} sessions</span>
+	</div>
+
+	{#if metrics}
+		<div class="spec-line">
+			RAM {Number.isFinite(metrics.ram_total_gb) ? metrics.ram_total_gb.toFixed(0) : '—'} GB ·
+			Disk {Number.isFinite(metrics.disk_total_gb) ? metrics.disk_total_gb.toFixed(0) : '—'} GB
+		</div>
+	{:else if !loading}
+		<div class="spec-line">—</div>
+	{/if}
+
+	{#if error}
+		<div class="card-error">
+			<span>{error}</span>
+			{#if onRetry}
+				<button class="retry-btn" onclick={onRetry}>Retry</button>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="gauges-row">
+		<RingGauge
+			pct={metrics?.cpu_pct ?? 0}
+			label="CPU"
+		/>
+		<RingGauge
+			pct={metrics?.ram_pct ?? 0}
+			label="RAM"
+			sublabel="{ramUsed} / {metrics && Number.isFinite(metrics.ram_total_gb) ? metrics.ram_total_gb.toFixed(0) : '—'} GB"
+		/>
+		<RingGauge
+			pct={metrics?.disk_pct ?? 0}
+			label="Disk"
+			sublabel="{diskUsed} / {metrics && Number.isFinite(metrics.disk_total_gb) ? metrics.disk_total_gb.toFixed(0) : '—'} GB"
+		/>
+	</div>
+</div>
+
+<style>
+	.host-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: 16px 20px;
+	}
+
+	.card-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 6px;
+	}
+
+	.hostname {
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+		font-family: var(--font-mono);
+		color: var(--text);
+	}
+
+	.sessions-badge {
+		background: color-mix(in srgb, var(--accent) 15%, transparent);
+		color: var(--accent);
+		font-size: 0.75rem;
+		font-weight: 600;
+		padding: 2px 10px;
+		border-radius: 12px;
+	}
+
+	.spec-line {
+		font-size: 0.82rem;
+		font-family: var(--font-mono);
+		color: var(--text-muted);
+		margin-bottom: 16px;
+	}
+
+	.gauges-row {
+		display: flex;
+		gap: 28px;
+		justify-content: center;
+		padding-top: 8px;
+	}
+
+	.card-error {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		background: color-mix(in srgb, #f44336 12%, transparent);
+		border: 1px solid color-mix(in srgb, #f44336 30%, transparent);
+		border-radius: var(--radius);
+		padding: 6px 12px;
+		font-size: 0.82rem;
+		color: #f44336;
+		margin-bottom: 12px;
+	}
+
+	.retry-btn {
+		background: none;
+		border: 1px solid #f44336;
+		border-radius: var(--radius);
+		color: #f44336;
+		cursor: pointer;
+		font-size: 0.78rem;
+		padding: 2px 8px;
+	}
+
+	.retry-btn:hover {
+		background: color-mix(in srgb, #f44336 15%, transparent);
+	}
+</style>

--- a/frontend/src/lib/components/KpiCard.svelte
+++ b/frontend/src/lib/components/KpiCard.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	let {
+		label,
+		value,
+		sublabel,
+		intent = 'default'
+	}: {
+		label: string;
+		value: string | number;
+		sublabel?: string;
+		intent?: 'default' | 'accent' | 'warn';
+	} = $props();
+</script>
+
+<div class="kpi-card kpi-{intent}">
+	<div class="kpi-label">{label}</div>
+	<div class="kpi-value">{value}</div>
+	{#if sublabel}
+		<div class="kpi-sub">{sublabel}</div>
+	{/if}
+</div>
+
+<style>
+	.kpi-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: 14px 16px;
+	}
+
+	.kpi-label {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-bottom: 6px;
+	}
+
+	.kpi-value {
+		font-family: var(--font-mono);
+		font-size: 1.6rem;
+		font-weight: 600;
+		color: var(--text);
+		line-height: 1.1;
+	}
+
+	.kpi-accent .kpi-value {
+		color: var(--accent);
+	}
+
+	.kpi-warn .kpi-value {
+		color: #ff9800;
+	}
+
+	.kpi-sub {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin-top: 4px;
+	}
+</style>

--- a/frontend/src/lib/components/RingGauge.svelte
+++ b/frontend/src/lib/components/RingGauge.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	let {
+		pct,
+		label,
+		size = 88,
+		strokeWidth = 8,
+		sublabel = ''
+	}: {
+		pct: number;
+		label: string;
+		size?: number;
+		strokeWidth?: number;
+		sublabel?: string;
+	} = $props();
+
+	function thresholdColor(p: number): string {
+		if (p >= 90) return '#f44336';
+		if (p >= 75) return '#ff9800';
+		if (p >= 50) return '#f5c518';
+		return '#4caf50';
+	}
+
+	let clamped = $derived(Number.isFinite(pct) ? Math.max(0, Math.min(100, pct)) : 0);
+	let radius = $derived((size - strokeWidth) / 2);
+	let circumference = $derived(2 * Math.PI * radius);
+	let offset = $derived(circumference * (1 - clamped / 100));
+	let color = $derived(thresholdColor(clamped));
+	let cx = $derived(size / 2);
+	let cy = $derived(size / 2);
+	let displayText = $derived(Number.isFinite(pct) ? `${Math.round(clamped)}%` : '—%');
+</script>
+
+<div class="gauge">
+	<svg width={size} height={size} viewBox="0 0 {size} {size}">
+		<circle
+			cx={cx}
+			cy={cy}
+			r={radius}
+			fill="none"
+			stroke="var(--border)"
+			stroke-width={strokeWidth}
+		/>
+		<circle
+			cx={cx}
+			cy={cy}
+			r={radius}
+			fill="none"
+			stroke={color}
+			stroke-width={strokeWidth}
+			stroke-linecap="round"
+			stroke-dasharray={circumference}
+			stroke-dashoffset={offset}
+			transform="rotate(-90 {cx} {cy})"
+		/>
+		<text
+			x={cx}
+			y={cy}
+			dominant-baseline="middle"
+			text-anchor="middle"
+			font-size="13"
+			font-family="var(--font-mono)"
+			fill="var(--text)"
+		>{displayText}</text>
+	</svg>
+	<div class="gauge-label">{label}</div>
+	{#if sublabel}
+		<div class="gauge-sub">{sublabel}</div>
+	{/if}
+</div>
+
+<style>
+	.gauge {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.gauge-label {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		font-family: var(--font-sans);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.gauge-sub {
+		font-size: 0.7rem;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+	}
+</style>

--- a/frontend/src/lib/components/SpendBarChart.svelte
+++ b/frontend/src/lib/components/SpendBarChart.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import type { DailyCost } from '$lib/types';
+
+	let {
+		days,
+		width = 480,
+		height = 160
+	}: {
+		days: DailyCost[];
+		width?: number;
+		height?: number;
+	} = $props();
+
+	const MARGIN = { top: 12, right: 8, bottom: 22, left: 36 };
+
+	function fmtDay(iso: string): string {
+		return iso.slice(5);
+	}
+
+	let visible = $derived(days.slice(0, 7).reverse());
+	let pw = $derived(width - MARGIN.left - MARGIN.right);
+	let ph = $derived(height - MARGIN.top - MARGIN.bottom);
+	let yMax = $derived(Math.max(...visible.map((d) => (Number.isFinite(d.usd) ? d.usd : 0)), 0.01));
+	let barCount = $derived(visible.length);
+	let slotWidth = $derived(barCount > 0 ? pw / barCount : pw);
+	let barWidth = $derived(slotWidth * 0.65);
+
+	function barX(i: number): number {
+		return MARGIN.left + i * slotWidth + (slotWidth - barWidth) / 2;
+	}
+
+	function barH(usd: number): number {
+		return (usd / yMax) * ph;
+	}
+
+	function barY(usd: number): number {
+		return MARGIN.top + ph - barH(usd);
+	}
+
+	function labelX(i: number): number {
+		return MARGIN.left + i * slotWidth + slotWidth / 2;
+	}
+
+	let gridLines = $derived([0, 0.5, 1].map((f) => ({
+		y: MARGIN.top + ph * (1 - f),
+		label: f === 0 ? '$0' : `$${(yMax * f).toFixed(2)}`
+	})));
+</script>
+
+{#if visible.length === 0}
+	<div class="empty">No cost data yet</div>
+{:else}
+	<svg {width} {height} viewBox="0 0 {width} {height}" style="width: 100%; max-width: {width}px;">
+		<!-- grid lines -->
+		{#each gridLines as gl}
+			<line
+				x1={MARGIN.left}
+				y1={gl.y}
+				x2={width - MARGIN.right}
+				y2={gl.y}
+				stroke="var(--border)"
+				stroke-width="1"
+			/>
+			<text
+				x={MARGIN.left - 4}
+				y={gl.y}
+				text-anchor="end"
+				dominant-baseline="middle"
+				font-size="9"
+				font-family="var(--font-mono)"
+				fill="var(--text-muted)"
+			>{gl.label}</text>
+		{/each}
+
+		<!-- bars -->
+		{#each visible as d, i}
+			<g>
+				<title>{d.date}: ${d.usd.toFixed(4)} · {d.tokens.toLocaleString()} tok</title>
+				<rect
+					x={barX(i)}
+					y={barY(d.usd)}
+					width={barWidth}
+					height={Math.max(barH(d.usd), 1)}
+					fill="var(--accent)"
+					rx="2"
+					opacity="0.85"
+				/>
+			</g>
+			<!-- x-axis label -->
+			{#if barCount <= 5 || i % 2 === 0}
+				<text
+					x={labelX(i)}
+					y={height - MARGIN.bottom + 14}
+					text-anchor="middle"
+					font-size="9"
+					font-family="var(--font-mono)"
+					fill="var(--text-muted)"
+				>{fmtDay(d.date)}</text>
+			{/if}
+		{/each}
+	</svg>
+{/if}
+
+<style>
+	.empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		min-height: 80px;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+	}
+</style>

--- a/frontend/src/lib/components/StateBadge.svelte
+++ b/frontend/src/lib/components/StateBadge.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { stateColor } from '$lib/utils';
+	import type { SessionState } from '$lib/types';
+
+	let { state }: { state: SessionState } = $props();
+</script>
+
+<span class="badge" style="background: color-mix(in srgb, {stateColor(state)} 18%, transparent); color: {stateColor(state)};">
+	{#if state === 'streaming'}
+		<span class="dot pulse"></span>
+	{/if}
+	{state}
+</span>
+
+<style>
+	.badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 8px;
+		border-radius: 12px;
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		white-space: nowrap;
+	}
+
+	.dot {
+		width: 5px;
+		height: 5px;
+		border-radius: 50%;
+		background: currentColor;
+	}
+
+	.pulse {
+		animation: pulse 1.2s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.3; }
+	}
+</style>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface AgentMeta {
 	version?: string | null;
 	model?: string | null;
 	tokens_used: number;
+	cost_dollars?: number | null;
 	last_tool_call?: string | null;
 }
 
@@ -207,3 +208,45 @@ export type LogWsMessage =
 	| { type: 'initial_tail_complete' }
 	| { type: 'lagged'; dropped: number }
 	| { type: 'set_sources'; sources: string[] };
+
+export interface HostMetrics {
+	hostname: string;
+	cpu_pct: number;
+	ram_pct: number;
+	disk_pct: number;
+	ram_total_gb: number;
+	disk_total_gb: number;
+}
+
+export interface DailyCost {
+	date: string;
+	usd: number;
+	tokens: number;
+}
+
+export interface DailyCostsResponse {
+	days: DailyCost[];
+}
+
+export interface PipelineGate {
+	smoke: boolean | null;
+	shots: number;
+	scenarios: number;
+}
+
+export interface PipelineRun {
+	issue: number;
+	title: string;
+	state: string;
+	phase: string;
+	host: string;
+	agents: unknown[];
+	cost_usd: number;
+	tokens: number;
+	started_at: string;
+	gate: PipelineGate;
+}
+
+export interface PipelineRunsResponse {
+	runs: PipelineRun[];
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,8 +1,9 @@
 import type { SessionState } from './types';
 
 export function formatIdleTime(lastActivityAt: number): string {
+	if (!Number.isFinite(lastActivityAt)) return '—';
 	const diffMs = Date.now() - lastActivityAt;
-	const secs = Math.floor(diffMs / 1000);
+	const secs = Math.max(0, Math.floor(diffMs / 1000));
 	if (secs < 60) return `${secs}s`;
 	const mins = Math.floor(secs / 60);
 	if (mins < 60) return `${mins}m`;
@@ -13,7 +14,7 @@ export function formatIdleTime(lastActivityAt: number): string {
 }
 
 export function formatTokens(n: number): string {
-	if (!n) return '—';
+	if (n == null || !Number.isFinite(n)) return '—';
 	return new Intl.NumberFormat().format(n);
 }
 
@@ -41,4 +42,9 @@ export function stateColor(state: SessionState): string {
 
 export function isActiveState(state: SessionState): boolean {
 	return state === 'booting' || state === 'idle' || state === 'streaming' || state === 'awaiting';
+}
+
+const IN_FLIGHT_STATES = new Set(['running', 'queued', 'pending', 'in_progress']);
+export function isPipelineInFlight(state: string): boolean {
+	return IN_FLIGHT_STATES.has(state.toLowerCase());
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -108,6 +108,8 @@
 		{#if !collapsed}
 			<nav class="nav-links">
 				<a href="/" class="nav-link" class:active={$page.url.pathname === '/'}>Sessions</a>
+				<a href="/command" class="nav-link" class:active={$page.url.pathname === '/command'}>Command</a>
+				<a href="/fleet" class="nav-link" class:active={$page.url.pathname === '/fleet'}>Fleet</a>
 				<a href="/logs" class="nav-link" class:active={$page.url.pathname === '/logs'}>Logs</a>
 			</nav>
 			{#if aliveSessions.length > 0}

--- a/frontend/src/routes/command/+page.svelte
+++ b/frontend/src/routes/command/+page.svelte
@@ -1,0 +1,484 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { getHostMetrics, getDailyCosts, getPipelineRuns } from '$lib/api';
+	import { sessionsStore } from '$lib/stores/sessions.svelte';
+	import { isPipelineInFlight, formatTokens, formatIdleTime } from '$lib/utils';
+	import KpiCard from '$lib/components/KpiCard.svelte';
+	import SpendBarChart from '$lib/components/SpendBarChart.svelte';
+	import RingGauge from '$lib/components/RingGauge.svelte';
+	import StateBadge from '$lib/components/StateBadge.svelte';
+	import type { HostMetrics, DailyCost, PipelineRun } from '$lib/types';
+
+	// --- state ---
+	let host = $state<HostMetrics | null>(null);
+	let hostErr = $state<string | null>(null);
+	let loadingHost = $state(true);
+
+	let days = $state<DailyCost[]>([]);
+	let costsErr = $state<string | null>(null);
+	let loadingCosts = $state(true);
+
+	let runs = $state<PipelineRun[]>([]);
+	let pipelinesErr = $state<string | null>(null);
+	let loadingPipelines = $state(true);
+
+	// --- derived ---
+	let activeSessions = $derived(sessionsStore.sessions.filter((s) => s.state !== 'exited'));
+	let today = $derived(days[0] ?? null);
+	let last7 = $derived(days.slice(0, 7));
+	let pipelinesRunning = $derived(runs.filter((r) => isPipelineInFlight(r.state)).length);
+
+	// --- retry fns (exposed so error banners can call them) ---
+	let retryHost = $state(0);
+	let retryCosts = $state(0);
+	let retryPipelines = $state(0);
+
+	// --- host metrics effect (5s) ---
+	$effect(() => {
+		retryHost; // reactive dependency
+		let alive = true;
+		const tick = async () => {
+			try {
+				const m = await getHostMetrics();
+				if (!alive) return;
+				host = m;
+				hostErr = null;
+			} catch (e) {
+				if (!alive) return;
+				hostErr = e instanceof Error ? e.message : 'Failed to load host metrics';
+			} finally {
+				if (alive) loadingHost = false;
+			}
+		};
+		tick();
+		const id = setInterval(tick, 5000);
+		return () => { alive = false; clearInterval(id); };
+	});
+
+	// --- costs effect (60s) ---
+	$effect(() => {
+		retryCosts; // reactive dependency
+		let alive = true;
+		const tick = async () => {
+			try {
+				const c = await getDailyCosts();
+				if (!alive) return;
+				days = c.days;
+				costsErr = null;
+			} catch (e) {
+				if (!alive) return;
+				costsErr = e instanceof Error ? e.message : 'Failed to load costs';
+			} finally {
+				if (alive) loadingCosts = false;
+			}
+		};
+		tick();
+		const id = setInterval(tick, 60_000);
+		return () => { alive = false; clearInterval(id); };
+	});
+
+	// --- pipeline runs effect (5s) ---
+	$effect(() => {
+		retryPipelines; // reactive dependency
+		let alive = true;
+		const tick = async () => {
+			try {
+				const r = await getPipelineRuns();
+				if (!alive) return;
+				runs = r.runs;
+				pipelinesErr = null;
+			} catch (e) {
+				if (!alive) return;
+				pipelinesErr = e instanceof Error ? e.message : 'Failed to load pipeline runs';
+			} finally {
+				if (alive) loadingPipelines = false;
+			}
+		};
+		tick();
+		const id = setInterval(tick, 5000);
+		return () => { alive = false; clearInterval(id); };
+	});
+</script>
+
+<div class="command-page">
+	<!-- KPI row -->
+	<div class="kpi-row">
+		<KpiCard label="Sessions Active" value={activeSessions.length} />
+		<KpiCard
+			label="Cost Today"
+			value={today ? '$' + today.usd.toFixed(2) : (loadingCosts ? '…' : '—')}
+		/>
+		<KpiCard
+			label="Tokens Today"
+			value={today ? formatTokens(today.tokens) : (loadingCosts ? '…' : '—')}
+		/>
+		<KpiCard
+			label="Pipelines Running"
+			value={loadingPipelines ? '…' : (pipelinesErr && runs.length === 0 ? '—' : pipelinesRunning)}
+		/>
+	</div>
+
+	<!-- Charts + fleet row -->
+	<div class="mid-row">
+		<!-- Spend bar chart -->
+		<div class="section-card chart-card">
+			<div class="section-header">
+				<h2>Spend, last 7 days</h2>
+			</div>
+			{#if costsErr}
+				<div class="error-banner">
+					{costsErr}
+					<button class="retry-btn" onclick={() => retryCosts++}>Retry</button>
+				</div>
+			{/if}
+			<div class="chart-wrap">
+				<SpendBarChart days={last7} />
+			</div>
+		</div>
+
+		<!-- Fleet gauges -->
+		<div class="section-card gauges-card">
+			<div class="section-header">
+				<h2>Host</h2>
+				{#if host}
+					<span class="host-name">{host.hostname}</span>
+				{/if}
+			</div>
+			{#if hostErr}
+				<div class="error-banner">
+					{hostErr}
+					<button class="retry-btn" onclick={() => retryHost++}>Retry</button>
+				</div>
+			{/if}
+			<div class="gauges-row">
+				<RingGauge pct={host?.cpu_pct ?? 0} label="CPU" size={80} />
+				<RingGauge pct={host?.ram_pct ?? 0} label="RAM" size={80} />
+				<RingGauge pct={host?.disk_pct ?? 0} label="Disk" size={80} />
+			</div>
+		</div>
+	</div>
+
+	<!-- Active sessions list -->
+	<div class="section-card">
+		<div class="section-header">
+			<h2>Active sessions</h2>
+			<span class="count-badge">{activeSessions.length}</span>
+		</div>
+		{#if activeSessions.length === 0}
+			<div class="empty-state">No active sessions</div>
+		{:else}
+			<div class="session-list">
+				{#each activeSessions as s (s.id)}
+					<button
+						class="session-row"
+						onclick={() => goto('/session/' + s.id)}
+					>
+						<span class="session-slug">{s.slug}</span>
+						<StateBadge state={s.state} />
+						<span class="session-tokens">
+							{formatTokens(s.agent_meta?.tokens_used ?? 0)} tok
+						</span>
+						<span class="cost-pill">
+							{s.agent_meta?.cost_dollars != null
+								? '$' + s.agent_meta.cost_dollars.toFixed(2)
+								: '—'}
+						</span>
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Pipelines in flight -->
+	<div class="section-card">
+		<div class="section-header">
+			<h2>Pipeline runs</h2>
+			<span class="count-badge">{runs.length}</span>
+		</div>
+		{#if pipelinesErr}
+			<div class="error-banner">
+				{pipelinesErr}
+				<button class="retry-btn" onclick={() => retryPipelines++}>Retry</button>
+			</div>
+		{/if}
+		{#if !loadingPipelines && runs.length === 0 && !pipelinesErr}
+			<div class="empty-state">No pipeline runs</div>
+		{:else}
+			<div class="pipeline-list">
+				{#each runs as run (`${run.issue}-${run.phase}-${run.started_at}`)}
+					<div class="pipeline-row">
+						<span class="pipeline-issue">#{run.issue}</span>
+						<span class="pipeline-state state-{run.state}">{run.state}</span>
+						<span class="pipeline-phase">{run.phase}</span>
+						<span class="pipeline-host">{run.host}</span>
+						<span class="pipeline-age">
+							{run.started_at ? formatIdleTime(new Date(run.started_at).getTime()) + ' ago' : '—'}
+						</span>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.command-page {
+		padding: 20px 24px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		max-width: 960px;
+	}
+
+	/* KPI row */
+	.kpi-row {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 12px;
+	}
+
+	/* Mid row: chart + gauges */
+	.mid-row {
+		display: grid;
+		grid-template-columns: 2fr 1fr;
+		gap: 16px;
+	}
+
+	/* Section cards */
+	.section-card {
+		background: var(--bg-surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: 16px;
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 12px;
+	}
+
+	.section-header h2 {
+		margin: 0;
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.count-badge {
+		font-size: 0.75rem;
+		font-family: var(--font-mono);
+		background: var(--bg-hover);
+		color: var(--text-muted);
+		padding: 1px 7px;
+		border-radius: 10px;
+	}
+
+	.host-name {
+		font-size: 0.82rem;
+		font-family: var(--font-mono);
+		color: var(--text-muted);
+		margin-left: auto;
+	}
+
+	/* Chart */
+	.chart-card {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.chart-wrap {
+		flex: 1;
+	}
+
+	/* Gauges */
+	.gauges-card {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.gauges-row {
+		display: flex;
+		gap: 16px;
+		justify-content: center;
+		padding: 8px 0;
+		flex: 1;
+		align-items: center;
+	}
+
+	/* Session list */
+	.session-list {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.session-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 8px 10px;
+		border-radius: var(--radius);
+		background: none;
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		width: 100%;
+		color: var(--text);
+		transition: background 0.1s;
+	}
+
+	.session-row:hover {
+		background: var(--bg-hover);
+	}
+
+	.session-slug {
+		flex: 1;
+		font-family: var(--font-mono);
+		font-size: 0.85rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		min-width: 0;
+	}
+
+	.session-tokens {
+		font-size: 0.75rem;
+		font-family: var(--font-mono);
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+
+	.cost-pill {
+		font-size: 0.75rem;
+		font-family: var(--font-mono);
+		color: var(--accent);
+		white-space: nowrap;
+		min-width: 3.5rem;
+		text-align: right;
+	}
+
+	/* Pipeline list */
+	.pipeline-list {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.pipeline-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 7px 10px;
+		border-radius: var(--radius);
+		font-size: 0.82rem;
+	}
+
+	.pipeline-row:hover {
+		background: var(--bg-hover);
+	}
+
+	.pipeline-issue {
+		font-family: var(--font-mono);
+		font-weight: 600;
+		color: var(--accent);
+		min-width: 3rem;
+	}
+
+	.pipeline-state {
+		font-size: 0.72rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		padding: 2px 8px;
+		border-radius: 10px;
+		background: var(--bg-hover);
+		color: var(--text-muted);
+	}
+
+	.pipeline-state.state-running,
+	.pipeline-state.state-in_progress {
+		background: color-mix(in srgb, #4caf50 18%, transparent);
+		color: #4caf50;
+	}
+
+	.pipeline-state.state-completed {
+		background: color-mix(in srgb, #5b8bd4 18%, transparent);
+		color: #5b8bd4;
+	}
+
+	.pipeline-state.state-failed {
+		background: color-mix(in srgb, #f44336 18%, transparent);
+		color: #f44336;
+	}
+
+	.pipeline-phase {
+		font-family: var(--font-mono);
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		flex: 1;
+	}
+
+	.pipeline-host {
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	.pipeline-age {
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		min-width: 2.5rem;
+		text-align: right;
+	}
+
+	/* Empty + error states */
+	.empty-state {
+		padding: 20px;
+		text-align: center;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+	}
+
+	.error-banner {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		background: color-mix(in srgb, #f44336 12%, transparent);
+		border: 1px solid color-mix(in srgb, #f44336 30%, transparent);
+		border-radius: var(--radius);
+		padding: 6px 12px;
+		font-size: 0.82rem;
+		color: #f44336;
+		margin-bottom: 10px;
+	}
+
+	.retry-btn {
+		background: none;
+		border: 1px solid #f44336;
+		border-radius: var(--radius);
+		color: #f44336;
+		cursor: pointer;
+		font-size: 0.78rem;
+		padding: 2px 8px;
+		margin-left: auto;
+		flex-shrink: 0;
+	}
+
+	.retry-btn:hover {
+		background: color-mix(in srgb, #f44336 15%, transparent);
+	}
+
+	@media (max-width: 700px) {
+		.kpi-row {
+			grid-template-columns: 1fr 1fr;
+		}
+		.mid-row {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/frontend/src/routes/command/+page.ts
+++ b/frontend/src/routes/command/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/frontend/src/routes/fleet/+page.svelte
+++ b/frontend/src/routes/fleet/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { getHostMetrics } from '$lib/api';
+	import { sessionsStore } from '$lib/stores/sessions.svelte';
+	import HostCard from '$lib/components/HostCard.svelte';
+	import type { HostMetrics } from '$lib/types';
+
+	let host = $state<HostMetrics | null>(null);
+	let err = $state<string | null>(null);
+	let loading = $state(true);
+	let retryHost = $state(0);
+
+	let activeSessionsCount = $derived(
+		sessionsStore.sessions.filter((s) => s.state !== 'exited').length
+	);
+
+	$effect(() => {
+		retryHost; // reactive dependency — incrementing restarts effect
+		let alive = true;
+		const tick = async () => {
+			try {
+				const m = await getHostMetrics();
+				if (!alive) return;
+				host = m;
+				err = null;
+			} catch (e) {
+				if (!alive) return;
+				err = e instanceof Error ? e.message : 'Failed to load host metrics';
+			} finally {
+				if (alive) loading = false;
+			}
+		};
+		tick();
+		const id = setInterval(tick, 5000);
+		return () => {
+			alive = false;
+			clearInterval(id);
+		};
+	});
+</script>
+
+<div class="fleet-page">
+	<div class="page-header">
+		<h1>Fleet</h1>
+	</div>
+
+	<div class="host-section">
+		<HostCard
+			metrics={host}
+			sessionsCount={activeSessionsCount}
+			{loading}
+			error={err}
+			onRetry={() => retryHost++}
+		/>
+	</div>
+
+	<div class="empty-remote">
+		<span>No remote hosts — single-host mode</span>
+	</div>
+</div>
+
+<style>
+	.fleet-page {
+		padding: 20px 24px;
+		max-width: 680px;
+	}
+
+	.page-header {
+		margin-bottom: 20px;
+	}
+
+	.page-header h1 {
+		margin: 0;
+		font-size: 1.2rem;
+		font-weight: 700;
+		color: var(--text);
+	}
+
+	.host-section {
+		margin-bottom: 20px;
+	}
+
+	.empty-remote {
+		padding: 16px 20px;
+		background: var(--bg-surface);
+		border: 1px dashed var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		font-size: 0.85rem;
+		text-align: center;
+	}
+</style>

--- a/frontend/src/routes/fleet/+page.ts
+++ b/frontend/src/routes/fleet/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
## Summary

- **`/command`** — dashboard overview: KPI row (sessions active, cost today, tokens today, pipelines running), 7-day SVG spend bar chart, active sessions list with state badges + cost pills, pipeline runs list, host CPU/RAM/disk ring gauges
- **`/fleet`** — localhost host card: hostname + RAM/disk spec, ring gauges, sessions count badge, remote-hosts empty state
- New reusable components: `RingGauge`, `KpiCard`, `StateBadge`, `SpendBarChart`, `HostCard`
- New API functions for `/api/v1/metrics/host`, `/api/v1/costs/daily`, `/api/v1/pipeline/runs`
- Nav links added to sidebar for both new routes
- All data from live endpoints; no hardcoded values; graceful empty/error states per section

## Test plan

- [ ] `/command` loads KPIs from API, shows `—` on fetch failure
- [ ] 7-day bar chart renders correct bars; shows "No cost data yet" when empty
- [ ] Active sessions list live-updates via existing sessionsStore poll
- [ ] Pipeline runs list shows empty state when none exist
- [ ] Ring gauges poll every 5s; color thresholds: green <50%, yellow 50-75%, orange 75-90%, red ≥90%
- [ ] `/fleet` host card shows hostname + spec line + 3 gauges + sessions count
- [ ] Retry button on error resets polling without race
- [ ] `pnpm --filter frontend check && pnpm --filter frontend build` — green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Command dashboard displaying key metrics: active sessions, daily costs, token usage, and pipeline activity.
  * Added spend visualization showing daily costs over the last 7 days.
  * Added Fleet management page with host resource monitoring (CPU, RAM, Disk gauges) and active session counts.
  * Added pipeline runs tracking with status and phase information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->