### PR TITLE
fix(metrics): exclude virtual/bind-mount filesystems from disk totals

### DIFF
--- a/backend/src/api/host_metrics.rs
+++ b/backend/src/api/host_metrics.rs
@@ -33,12 +33,22 @@ pub async fn get_host_metrics() -> Json<HostMetrics> {
     };
 
     let disks = Disks::new_with_refreshed_list();
-    let (disk_total, disk_used) = disks.iter().fold((0u64, 0u64), |(t, u), d| {
-        (
-            t + d.total_space(),
-            u + d.total_space().saturating_sub(d.available_space()),
-        )
-    });
+    // Exclude virtual/network/bind-mount filesystems that inflate totals inside
+    // containers (e.g. fuse.grpcfuse is OrbStack's macOS bind mount, overlay
+    // is the container root layer, tmpfs/devtmpfs are in-memory).
+    const EXCLUDED_FS: &[&str] = &["tmpfs", "devtmpfs", "overlay", "fuse.grpcfuse", "fuse"];
+    let (disk_total, disk_used) = disks
+        .iter()
+        .filter(|d| {
+            let fs = d.file_system().to_string_lossy().to_lowercase();
+            !EXCLUDED_FS.iter().any(|ex| fs.contains(ex))
+        })
+        .fold((0u64, 0u64), |(t, u), d| {
+            (
+                t + d.total_space(),
+                u + d.total_space().saturating_sub(d.available_space()),
+            )
+        });
     let disk_total_gb = disk_total as f64 / (1024.0 * 1024.0 * 1024.0);
     let disk_pct = if disk_total > 0 {
         disk_used as f64 / disk_total as f64 * 100.0


### PR DESCRIPTION
Fixes disk_total_gb showing ~120 TB inside Docker on macOS (OrbStack's fuse.grpcfuse bind mount was included in the sum). Now filters tmpfs, devtmpfs, overlay, fuse.grpcfuse, fuse before accumulating disk totals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced disk usage metrics accuracy by excluding virtual and temporary filesystem types (tmpfs, devtmpfs, overlay, fuse mounts) that artificially inflate reported disk totals within containerized and virtualized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->