### PR TITLE
fix(metrics): expose host hostname via HANGAR_HOSTNAME env var

### DIFF
--- a/backend/src/api/host_metrics.rs
+++ b/backend/src/api/host_metrics.rs
@@ -53,7 +53,10 @@ pub async fn get_host_metrics() -> Json<HostMetrics> {
         0.0
     };
 
-    let hostname = System::host_name().unwrap_or_else(|| "unknown".to_string());
+    let hostname = std::env::var("HANGAR_HOSTNAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| System::host_name().unwrap_or_else(|| "unknown".to_string()));
 
     Json(HostMetrics {
         hostname,

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -25,6 +25,7 @@ services:
       - HANGAR_PORT=3000
       - HANGAR_STATE_DIR=/state
       - RUST_LOG=info
+      - HANGAR_HOSTNAME=${HOSTNAME}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/v1/metrics"]


### PR DESCRIPTION
Container was showing its own container ID as hostname. compose.yml now passes `HANGAR_HOSTNAME=$HOSTNAME` from the host shell; backend reads it first with sysinfo fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hostname configuration now available through the `HANGAR_HOSTNAME` environment variable, with automatic fallback to system hostname detection if not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->