### PR TITLE
fix(deploy): set container hostname to Georges-Mac-mini

### DIFF
--- a/backend/src/api/host_metrics.rs
+++ b/backend/src/api/host_metrics.rs
@@ -53,10 +53,7 @@ pub async fn get_host_metrics() -> Json<HostMetrics> {
         0.0
     };
 
-    let hostname = std::env::var("HANGAR_HOSTNAME")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| System::host_name().unwrap_or_else(|| "unknown".to_string()));
+    let hostname = System::host_name().unwrap_or_else(|| "unknown".to_string());
 
     Json(HostMetrics {
         hostname,

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -21,11 +21,11 @@ services:
       # User code visible inside the container under /code so agents can edit it.
       # Anything written here lands on the host at ~/Documents/code/...
       - ${HOME}/Documents/code:/code
+    hostname: Georges-Mac-mini
     environment:
       - HANGAR_PORT=3000
       - HANGAR_STATE_DIR=/state
       - RUST_LOG=info
-      - HANGAR_HOSTNAME=${HOSTNAME}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/v1/metrics"]


### PR DESCRIPTION
$HOSTNAME isn't exported in zsh so env-var injection silently passed empty string. Using Docker compose `hostname:` field — sysinfo reads the container's own hostname directly.